### PR TITLE
Removing Segment/Subsegment name invalid characters

### DIFF
--- a/aws_xray_sdk/core/models/entity.py
+++ b/aws_xray_sdk/core/models/entity.py
@@ -2,6 +2,7 @@ import logging
 import os
 import binascii
 import time
+import string
 
 import jsonpickle
 
@@ -13,19 +14,27 @@ from ..exceptions.exceptions import AlreadyEndedException
 
 log = logging.getLogger(__name__)
 
+# List of valid characters found at http://docs.aws.amazon.com/xray/latest/devguide/xray-api-segmentdocuments.html
+_valid_name_characters = string.ascii_letters + string.digits + '_.:/%&#=+\-@ '
+
 
 class Entity(object):
     """
     The parent class for segment/subsegment. It holds common properties
     and methods on segment and subsegment.
     """
+
     def __init__(self, name):
 
         # required attributes
         self.id = self._generate_random_id()
         self.name = name
+        self.name = ''.join([c for c in name if c in _valid_name_characters])
         self.start_time = time.time()
         self.parent_id = None
+
+        if self.name != name:
+            log.warning("Removing Segment/Subsugment Name invalid characters.")
 
         # sampling
         self.sampled = True

--- a/tests/test_dummy_entites.py
+++ b/tests/test_dummy_entites.py
@@ -57,3 +57,11 @@ def test_structure_intact():
     subsegment.close()
     segment.close()
     assert segment.ready_to_send()
+
+
+def test_invalid_entity_name():
+    segment = DummySegment('DummySegment() Test?')
+    subsegment = DummySubsegment(segment, 'Dummy*Sub!segment$')
+
+    assert segment.name == 'DummySegment Test'
+    assert subsegment.name == 'DummySubsegment'


### PR DESCRIPTION
If you create segment/subsegments with invalid Name characters, this causes issues in the X-Ray traces. This Pull Request remove the invalid characters and adds a warning in the log. I added the changes requested by @haotianw465 on PR #8. Sorry for the second PR, I had some trouble with my other branch.