### PR TITLE
Fixing Django 2.0 and TestClass tests errors

### DIFF
--- a/tests/ext/aiohttp/test_aiohttp.py
+++ b/tests/ext/aiohttp/test_aiohttp.py
@@ -19,6 +19,7 @@ class CustomStubbedEmitter(UDPEmitter):
     """
     Custom stubbed emitter which stores all segments instead of the last one
     """
+
     def __init__(self, daemon_address='127.0.0.1:2000'):
         super(CustomStubbedEmitter, self).__init__(daemon_address)
         self.local = []
@@ -37,6 +38,8 @@ class TestServer(object):
     """
     Simple class to hold a copy of the event loop
     """
+    __test__ = False
+
     def __init__(self, loop):
         self._loop = loop
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = 
+envlist =
     py{27,34,35,36}
     coverage-report
 
@@ -12,8 +12,8 @@ deps =
     botocore
     requests
     flask >= 0.10
-    # the sdk dosen't support earlier version of django
-    django >= 1.10
+    # the sdk doesn't support earlier version of django
+    django >= 1.10, <2.0
     # Python3.5+ only deps
     py{35,36}: aiohttp >= 2.3.0
     py{35,36}: pytest-aiohttp


### PR DESCRIPTION
By adding __test__ = False in the TestServer Class, pytest ignores it so we don't get the warning message.

Django 2.0 is out and it causes errors with actual tests. I never used Django so I am not the best person to port the tests to 2.0 but with this change in tox.ini, Python 3 tests are not failing.