### PR TITLE
Fix error code flag when using Python 3

### DIFF
--- a/aws_xray_sdk/ext/boto_utils.py
+++ b/aws_xray_sdk/ext/boto_utils.py
@@ -69,11 +69,6 @@ def _aws_error_handler(exception, stack, subsegment, aws_meta):
     status_code = response_metadata.get('HTTPStatusCode')
 
     subsegment.put_http_meta(http.STATUS, status_code)
-    if status_code == 429:
-        subsegment.add_throttle_flag()
-    if status_code / 100 == 4:
-        subsegment.add_error_flag()
-
     subsegment.add_exception(exception, stack, True)
 
 


### PR DESCRIPTION
When using Python 3 the error code flag was never set, thanks to the
division changes between Python 2 and Python 3.

The behavior before this commit was:

Python2:

```
>>> status_code = 403
>>> status_code / 100 == 4
True
```

Python3:

```
>>> status_code = 403
>>> status_code / 100 == 4
False
```
