### PR TITLE
Support patching PynamoDB calls to DynamoDB

### DIFF
--- a/aws_xray_sdk/ext/pynamodb/__init__.py
+++ b/aws_xray_sdk/ext/pynamodb/__init__.py
@@ -1,0 +1,3 @@
+from .patch import patch
+
+__all__ = ['patch']

--- a/aws_xray_sdk/ext/pynamodb/patch.py
+++ b/aws_xray_sdk/ext/pynamodb/patch.py
@@ -1,0 +1,63 @@
+import botocore.vendored.requests.sessions
+import json
+import wrapt
+
+from aws_xray_sdk.core import xray_recorder
+from aws_xray_sdk.core.models import http
+from aws_xray_sdk.ext.boto_utils import _extract_whitelisted_params
+
+
+def patch():
+    """Patch PynamoDB so it generates subsegements when calling DynamoDB."""
+    if hasattr(botocore.vendored.requests.sessions, '_xray_enabled'):
+        return
+    setattr(botocore.vendored.requests.sessions, '_xray_enabled', True)
+
+    wrapt.wrap_function_wrapper(
+        'botocore.vendored.requests.sessions',
+        'Session.send',
+        _xray_traced_pynamodb,
+    )
+
+
+def _xray_traced_pynamodb(wrapped, instance, args, kwargs):
+
+    # Check if it's a request to DynamoDB and return otherwise.
+    try:
+        service = args[0].headers['X-Amz-Target'].decode('utf-8').split('_')[0]
+    except KeyError:
+        return wrapped(*args, **kwargs)
+    if service.lower() != 'dynamodb':
+        return wrapped(*args, **kwargs)
+
+    return xray_recorder.record_subsegment(
+        wrapped, instance, args, kwargs,
+        name='dynamodb',
+        namespace='aws',
+        meta_processor=pynamodb_meta_processor,
+    )
+
+
+def pynamodb_meta_processor(wrapped, instance, args, kwargs, return_value,
+                            exception, subsegment, stack):
+    operation_name = args[0].headers['X-Amz-Target'].decode('utf-8').split('.')[1]
+    region = args[0].url.split('.')[1]
+    request_id = return_value.headers.get('x-amzn-RequestId')
+
+    aws_meta = {
+        'operation': operation_name,
+        'request_id': request_id,
+        'region': region
+    }
+
+    if exception:
+        subsegment.add_error_flag()
+        subsegment.add_exception(exception, stack, True)
+
+    subsegment.put_http_meta(http.STATUS, return_value.status_code)
+
+    _extract_whitelisted_params(subsegment.name, operation_name,
+                                aws_meta, [None, json.loads(args[0].body)],
+                                None, return_value.json())
+
+    subsegment.set_aws(aws_meta)

--- a/docs/aws_xray_sdk.ext.pynamodb.rst
+++ b/docs/aws_xray_sdk.ext.pynamodb.rst
@@ -1,0 +1,22 @@
+aws\_xray\_sdk\.ext\.pynamodb package
+=====================================
+
+Submodules
+----------
+
+aws\_xray\_sdk\.ext\.pynamodb\.patch module
+-------------------------------------------
+
+.. automodule:: aws_xray_sdk.ext.pynamodb.patch
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: aws_xray_sdk.ext.pynamodb
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -23,8 +23,9 @@ Currently supported web frameworks and libraries:
 * flask
 * boto3
 * botocore
+* pynamodb
 * requests
-* sqlite3 
+* sqlite3
 * mysql-connector
 
 You must have the X-Ray daemon running to use the SDK.

--- a/docs/thirdparty.rst
+++ b/docs/thirdparty.rst
@@ -6,10 +6,11 @@ Third Party Library Support
 Patching Supported Libraries
 ----------------------------
 
-The SDK supports aioboto3, aiobotocore, boto3, botocore, requests, sqlite3 and mysql-connector.
+The SDK supports aioboto3, aiobotocore, boto3, botocore, pynamodb, requests, sqlite3 and
+mysql-connector.
 
 To patch, use code like the following in the main app::
-    
+
     from aws_xray_sdk.core import patch_all
 
     patch_all()
@@ -30,12 +31,16 @@ The following modules are availble to patch::
         'aiobotocore',
         'boto3',
         'botocore',
+        'pynamodb',
         'requests',
         'sqlite3',
         'mysql',
     )
 
-Patching boto3 and botocore are equivalent since boto3 depends on botocore
+Patching boto3 and botocore are equivalent since boto3 depends on botocore.
+
+Patching pynamodb applies the botocore patch as well, as it uses the logic from the botocore
+patch to apply the trace header.
 
 Patching mysql
 ----------------------------

--- a/tests/ext/pynamodb/test_pynamodb.py
+++ b/tests/ext/pynamodb/test_pynamodb.py
@@ -1,0 +1,74 @@
+import botocore.session
+import pytest
+from botocore.exceptions import ClientError
+from pynamodb.attributes import UnicodeAttribute
+from pynamodb.exceptions import VerboseClientError
+from pynamodb.models import Model
+
+from aws_xray_sdk.core import patch
+from aws_xray_sdk.core import xray_recorder
+from aws_xray_sdk.core.context import Context
+
+patch(('pynamodb',))
+
+
+@pytest.fixture(autouse=True)
+def construct_ctx():
+    """
+    Clean up context storage on each test run and begin a segment
+    so that later subsegment can be attached. After each test run
+    it cleans up context storage again.
+    """
+    xray_recorder.configure(service='test', sampling=False, context=Context())
+    xray_recorder.clear_trace_entities()
+    xray_recorder.begin_segment('name')
+    yield
+    xray_recorder.clear_trace_entities()
+
+
+def test_exception():
+    class SampleModel(Model):
+        class Meta:
+            region = 'us-west-2'
+            table_name = 'mytable'
+
+        sample_attribute = UnicodeAttribute(hash_key=True)
+
+    try:
+        SampleModel.describe_table()
+    except VerboseClientError:
+        pass
+
+    subsegments = xray_recorder.current_segment().subsegments
+    assert len(subsegments) == 1
+    subsegment = subsegments[0]
+    assert subsegment.name == 'dynamodb'
+    assert len(subsegment.subsegments) == 0
+    assert subsegment.error
+
+    aws_meta = subsegment.aws
+    assert aws_meta['region'] == 'us-west-2'
+    assert aws_meta['operation'] == 'DescribeTable'
+    assert aws_meta['table_name'] == 'mytable'
+
+
+def test_only_dynamodb_calls_are_traced():
+    """Test only a single subsegment is created for other AWS services.
+
+    As the pynamodb patch applies the botocore patch as well, we need
+    to ensure that only one subsegment is created for all calls not
+    made by PynamoDB. As PynamoDB calls botocore differently than the
+    botocore patch expects we also just get a single subsegment per
+    PynamoDB call.
+    """
+    session = botocore.session.get_session()
+    s3 = session.create_client('s3', region_name='us-west-2')
+    try:
+        s3.get_bucket_location(Bucket='mybucket')
+    except ClientError:
+        pass
+
+    subsegments = xray_recorder.current_segment().subsegments
+    assert len(subsegments) == 1
+    assert subsegments[0].name == 's3'
+    assert len(subsegments[0].subsegments) == 0

--- a/tox.ini
+++ b/tox.ini
@@ -14,6 +14,7 @@ deps =
     flask >= 0.10
     # the sdk doesn't support earlier version of django
     django >= 1.10, <2.0
+    pynamodb
     # Python3.5+ only deps
     py{35,36}: aiohttp >= 2.3.0
     py{35,36}: pytest-aiohttp


### PR DESCRIPTION
While [PynamoDB][1] uses `botocore` under the hood it doesn't call
`botocore`'s [`BaseClient._make_api_call`][2]. Instead it implements its own
[`Connection._make_api_call`][2], making it necessary to separately patch
PynamoDB, even though it uses `botocore`.

As PynamoDB's `Connection._make_api_call` doesn't return information
about the response as `botocore` does, there is no response information
to pass to AWS X-Ray.

For adding the trace header patching `botocore` is sufficient, as
PynamoDB does use `botocore`'s prepared requests. To make that work out
of the box the overall patching logic got adjusted to automatically
patch `botocore` as well when pynamodb patching is selected.

For tests I tried to do something useful, but only came up with the
single test which calls real DynamoDB.

I'm not sure if patching `_make_api_call` is the right approach at all
or if it would be better to patch the
`requests.session.Session.send`-call in PynamoDB. That would give
access to the response data, while causing a separate subsegment per
retry in case of throttling.

So I'm looking forward to get some feedback.

All in all it's pretty annoying that PynamoDB needs additional logic
while it uses `botocore` and `requests` which are both already
supported.

[1]: https://github.com/pynamodb/PynamoDB
[2]: https://github.com/boto/botocore/blob/06f34bb4409da12efb20f154e943d04d47cfe748/botocore/client.py#L568-L614
[3]: https://github.com/pynamodb/PynamoDB/blob/d100b6594ade5381192cfd42874ac2588a02fd1f/pynamodb/connection/base.py#L335-L418
