### PR TITLE
httplib support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ dist
 *.egg-info
 .tox
 .python-version
+.pytest_cache
 
 pip-selfcheck.json
 

--- a/aws_xray_sdk/core/patcher.py
+++ b/aws_xray_sdk/core/patcher.py
@@ -10,7 +10,7 @@ SUPPORTED_MODULES = (
     'requests',
     'sqlite3',
     'mysql',
-    'httplib',  # TODO: perhaps requests should map to this below
+    'httplib',
 )
 
 _PATCHED_MODULES = set()

--- a/aws_xray_sdk/core/patcher.py
+++ b/aws_xray_sdk/core/patcher.py
@@ -10,6 +10,7 @@ SUPPORTED_MODULES = (
     'requests',
     'sqlite3',
     'mysql',
+    'httplib',  # TODO: perhaps requests should map to this below
 )
 
 _PATCHED_MODULES = set()

--- a/aws_xray_sdk/ext/httplib/__init__.py
+++ b/aws_xray_sdk/ext/httplib/__init__.py
@@ -1,0 +1,3 @@
+from .patch import patch
+
+__all__ = ['patch']

--- a/aws_xray_sdk/ext/httplib/patch.py
+++ b/aws_xray_sdk/ext/httplib/patch.py
@@ -4,7 +4,7 @@ import wrapt
 
 from aws_xray_sdk.core import xray_recorder
 from aws_xray_sdk.core.models import http
-from aws_xray_sdk.ext.util import inject_trace_header, _strip_url
+from aws_xray_sdk.ext.util import inject_trace_header, strip_url
 
 import ssl
 
@@ -46,7 +46,7 @@ def _xray_traced_http_client(wrapped, instance, args, kwargs):
 
     return xray_recorder.record_subsegment(
         wrapped, instance, args, kwargs,
-        name=_strip_url(xray_data.url),
+        name=strip_url(xray_data.url),
         namespace='remote',
         meta_processor=http_response_processor,
     )
@@ -77,7 +77,7 @@ def _prep_request(wrapped, instance, args, kwargs):
         # we add a segment here in case connect fails
         return xray_recorder.record_subsegment(
             wrapped, instance, args, kwargs,
-            name=_strip_url(xray_data.url),
+            name=strip_url(xray_data.url),
             namespace='remote',
             meta_processor=http_request_processor
         )
@@ -103,7 +103,7 @@ def _xray_traced_http_client_read(wrapped, instance, args, kwargs):
 
     return xray_recorder.record_subsegment(
         wrapped, instance, args, kwargs,
-        name=_strip_url(xray_data.url),
+        name=strip_url(xray_data.url),
         namespace='remote',
         meta_processor=http_read_processor
     )

--- a/aws_xray_sdk/ext/httplib/patch.py
+++ b/aws_xray_sdk/ext/httplib/patch.py
@@ -1,0 +1,97 @@
+import wrapt
+
+from aws_xray_sdk.core import xray_recorder
+from aws_xray_sdk.core.models import http
+from aws_xray_sdk.ext.util import inject_trace_header
+
+import ssl
+
+
+_XRAY_PROP = '_xray_prop'
+
+
+def http_response_processor(wrapped, instance, args, kwargs, return_value,
+                            exception, subsegment, stack):
+    method, host, url = getattr(instance, _XRAY_PROP)
+
+    subsegment.put_http_meta(http.METHOD, method)
+    subsegment.put_http_meta(http.URL, url)
+
+    if return_value:
+        # propagate to response object
+        setattr(return_value, _XRAY_PROP, ('READ', host, url))
+        subsegment.put_http_meta(http.STATUS, return_value.code)
+
+    if exception:
+        subsegment.add_exception(exception, stack)
+
+
+def _xray_traced_http_client(wrapped, instance, args, kwargs):
+    if kwargs.get('buffering', False):
+        return wrapped(*args, **kwargs)  # ignore py2 calls that fail as 'buffering` only exists in py2.
+
+    method, host, url = getattr(instance, _XRAY_PROP)
+
+    return xray_recorder.record_subsegment(
+        wrapped, instance, args, kwargs,
+        name=host,
+        namespace='remote',
+        meta_processor=http_response_processor,
+    )
+
+
+def _prep_request(wrapped, instance, args, kwargs):
+    def decompose_args(method, url, body, headers, encode_chunked):
+        inject_trace_header(headers, xray_recorder.current_subsegment())
+
+        # we have to check against sock because urllib3's HTTPSConnection inherit's from http.client.HTTPConnection
+        scheme = 'https' if isinstance(instance.sock, ssl.SSLSocket) else 'http'
+        setattr(instance, _XRAY_PROP, (method, instance.host, '{}://{}{}'.format(scheme, instance.host, url)))
+        return wrapped(*args, **kwargs)
+
+    return decompose_args(*args, **kwargs)
+
+
+def http_read_processor(wrapped, instance, args, kwargs, return_value,
+                        exception, subsegment, stack):
+    method, host, url = getattr(instance, _XRAY_PROP)
+
+    # we don't delete the attr as we can have multiple reads
+    subsegment.put_http_meta(http.METHOD, method)
+    subsegment.put_http_meta(http.URL, url)
+    subsegment.put_http_meta(http.STATUS, instance.status)
+    subsegment.apply_status_code(instance.status)
+
+    if exception:
+        subsegment.add_exception(exception, stack)
+
+
+def _xray_traced_http_client_read(wrapped, instance, args, kwargs):
+    method, host, url = getattr(instance, _XRAY_PROP)
+
+    return xray_recorder.record_subsegment(
+        wrapped, instance, args, kwargs,
+        name=host,
+        namespace='remote',
+        meta_processor=http_read_processor,
+    )
+
+
+def patch():
+    wrapt.wrap_function_wrapper(
+        'http.client',
+        'HTTPConnection._send_request',
+        _prep_request
+    )
+
+    wrapt.wrap_function_wrapper(
+        'http.client',
+        'HTTPConnection.getresponse',
+        _xray_traced_http_client
+    )
+
+    wrapt.wrap_function_wrapper(
+        'http.client',
+        'HTTPResponse.read',
+        _xray_traced_http_client_read
+    )

--- a/aws_xray_sdk/ext/httplib/patch.py
+++ b/aws_xray_sdk/ext/httplib/patch.py
@@ -12,6 +12,12 @@ _XRAY_PROP = '_xray_prop'
 _XRay_Data = namedtuple('xray_data', ['method', 'host', 'url'])
 
 
+# TODO: this should apply to the requests module as well
+# ? is not a valid entity, and we don't want things after the ? anyways
+def _strip_url(url: str):
+    return url.partition('?')[0]
+
+
 def http_response_processor(wrapped, instance, args, kwargs, return_value,
                             exception, subsegment, stack):
     xray_data = getattr(instance, _XRAY_PROP)
@@ -38,7 +44,7 @@ def _xray_traced_http_client(wrapped, instance, args, kwargs):
 
     return xray_recorder.record_subsegment(
         wrapped, instance, args, kwargs,
-        name=xray_data.url,
+        name=_strip_url(xray_data.url),
         namespace='remote',
         meta_processor=http_response_processor,
     )
@@ -68,7 +74,7 @@ def _prep_request(wrapped, instance, args, kwargs):
 
         return xray_recorder.record_subsegment(
             wrapped, instance, args, kwargs,
-            name=xray_data.url,
+            name=_strip_url(xray_data.url),
             namespace='remote',
             meta_processor=http_request_processor
         )
@@ -95,7 +101,7 @@ def _xray_traced_http_client_read(wrapped, instance, args, kwargs):
 
     return xray_recorder.record_subsegment(
         wrapped, instance, args, kwargs,
-        name=xray_data.url,
+        name=_strip_url(xray_data.url),
         namespace='remote',
         meta_processor=http_read_processor
     )

--- a/aws_xray_sdk/ext/httplib/patch.py
+++ b/aws_xray_sdk/ext/httplib/patch.py
@@ -12,8 +12,7 @@ _XRAY_PROP = '_xray_prop'
 _XRay_Data = namedtuple('xray_data', ['method', 'host', 'url'])
 
 
-# TODO: this should apply to the requests module as well
-# ? is not a valid entity, and we don't want things after the ? anyways
+# ? is not a valid entity, and we don't want things after the ? for the segment name
 def _strip_url(url: str):
     return url.partition('?')[0]
 

--- a/aws_xray_sdk/ext/httplib/patch.py
+++ b/aws_xray_sdk/ext/httplib/patch.py
@@ -38,7 +38,7 @@ def http_response_processor(wrapped, instance, args, kwargs, return_value,
         subsegment.add_exception(exception, stack)
 
 
-def _xray_traced_http_client(wrapped, instance, args, kwargs):
+def _xray_traced_http_getresponse(wrapped, instance, args, kwargs):
     if kwargs.get('buffering', False):
         return wrapped(*args, **kwargs)  # ignore py2 calls that fail as 'buffering` only exists in py2.
 
@@ -119,7 +119,7 @@ def patch():
     wrapt.wrap_function_wrapper(
         httplib_client_module,
         'HTTPConnection.getresponse',
-        _xray_traced_http_client
+        _xray_traced_http_getresponse
     )
 
     wrapt.wrap_function_wrapper(

--- a/aws_xray_sdk/ext/requests/patch.py
+++ b/aws_xray_sdk/ext/requests/patch.py
@@ -2,8 +2,7 @@ import wrapt
 
 from aws_xray_sdk.core import xray_recorder
 from aws_xray_sdk.core.models import http
-from aws_xray_sdk.ext.util import inject_trace_header
-from aws_xray_sdk.ext.httplib.patch import _strip_url
+from aws_xray_sdk.ext.util import inject_trace_header, _strip_url
 
 
 def patch():

--- a/aws_xray_sdk/ext/requests/patch.py
+++ b/aws_xray_sdk/ext/requests/patch.py
@@ -3,6 +3,7 @@ import wrapt
 from aws_xray_sdk.core import xray_recorder
 from aws_xray_sdk.core.models import http
 from aws_xray_sdk.ext.util import inject_trace_header
+from aws_xray_sdk.ext.httplib.patch import _strip_url
 
 
 def patch():
@@ -26,7 +27,7 @@ def _xray_traced_requests(wrapped, instance, args, kwargs):
 
     return xray_recorder.record_subsegment(
         wrapped, instance, args, kwargs,
-        name=url,
+        name=_strip_url(url),
         namespace='remote',
         meta_processor=requests_processor,
     )

--- a/aws_xray_sdk/ext/requests/patch.py
+++ b/aws_xray_sdk/ext/requests/patch.py
@@ -2,7 +2,7 @@ import wrapt
 
 from aws_xray_sdk.core import xray_recorder
 from aws_xray_sdk.core.models import http
-from aws_xray_sdk.ext.util import inject_trace_header, _strip_url
+from aws_xray_sdk.ext.util import inject_trace_header, strip_url
 
 
 def patch():
@@ -26,7 +26,7 @@ def _xray_traced_requests(wrapped, instance, args, kwargs):
 
     return xray_recorder.record_subsegment(
         wrapped, instance, args, kwargs,
-        name=_strip_url(url),
+        name=strip_url(url),
         namespace='remote',
         meta_processor=requests_processor,
     )

--- a/aws_xray_sdk/ext/util.py
+++ b/aws_xray_sdk/ext/util.py
@@ -89,3 +89,8 @@ def to_snake_case(name):
     s1 = first_cap_re.sub(r'\1_\2', name)
     # handle acronym words
     return all_cap_re.sub(r'\1_\2', s1).lower()
+
+
+# ? is not a valid entity, and we don't want things after the ? for the segment name
+def _strip_url(url: str):
+    return url.partition('?')[0]

--- a/aws_xray_sdk/ext/util.py
+++ b/aws_xray_sdk/ext/util.py
@@ -92,5 +92,10 @@ def to_snake_case(name):
 
 
 # ? is not a valid entity, and we don't want things after the ? for the segment name
-def _strip_url(url: str):
-    return url.partition('?')[0]
+def strip_url(url: str):
+    """
+    Will generate a valid url string for use as a segment name
+    :param url: url to strip
+    :return: validated url string
+    """
+    return url.partition('?')[0] if url else url

--- a/docs/aws_xray_sdk.ext.httplib.rst
+++ b/docs/aws_xray_sdk.ext.httplib.rst
@@ -1,0 +1,22 @@
+aws\_xray\_sdk\.ext\.httplib package
+=====================================
+
+Submodules
+----------
+
+aws\_xray\_sdk\.ext\.httplib\.patch module
+-------------------------------------------
+
+.. automodule:: aws_xray_sdk.ext.httplib.patch
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: aws_xray_sdk.ext.httplib
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/aws_xray_sdk.ext.rst
+++ b/docs/aws_xray_sdk.ext.rst
@@ -14,6 +14,7 @@ Subpackages
     aws_xray_sdk.ext.mysql
     aws_xray_sdk.ext.requests
     aws_xray_sdk.ext.sqlite3
+    aws_xray_sdk.ext.httplib
 
 Submodules
 ----------

--- a/docs/thirdparty.rst
+++ b/docs/thirdparty.rst
@@ -6,7 +6,7 @@ Third Party Library Support
 Patching Supported Libraries
 ----------------------------
 
-The SDK supports aioboto3, aiobotocore, boto3, botocore, pynamodb, requests, sqlite3 and
+The SDK supports aioboto3, aiobotocore, boto3, botocore, pynamodb, requests, sqlite3, httplib and
 mysql-connector.
 
 To patch, use code like the following in the main app::
@@ -35,6 +35,7 @@ The following modules are availble to patch::
         'requests',
         'sqlite3',
         'mysql',
+        'httplib',
     )
 
 Patching boto3 and botocore are equivalent since boto3 depends on botocore.
@@ -73,3 +74,10 @@ up the X-Ray SDK with an Async Context, bear in mind this requires Python 3.5+::
 
 See :ref:`Configure Global Recorder <configurations>` for more information about
 configuring the ``xray_recorder``.
+
+Patching httplib
+----------------
+
+httplib is a low-level python module which is used by several third party modules, so
+by enabling patching to this module you can gain patching of many modules "for free."
+Some examples of modules that depend on httplib: requests and httplib2

--- a/tests/ext/httplib/test_httplib.py
+++ b/tests/ext/httplib/test_httplib.py
@@ -1,0 +1,95 @@
+import pytest
+import requests
+
+from aws_xray_sdk.core import patch
+from aws_xray_sdk.core import xray_recorder
+from aws_xray_sdk.core.context import Context
+
+
+patch(('httplib',))
+
+# httpbin.org is created by the same author of requests to make testing http easy.
+BASE_URL = 'httpbin.org'
+
+
+@pytest.fixture(autouse=True)
+def construct_ctx():
+    """
+    Clean up context storage on each test run and begin a segment
+    so that later subsegment can be attached. After each test run
+    it cleans up context storage again.
+    """
+    xray_recorder.configure(service='test', sampling=False, context=Context())
+    xray_recorder.clear_trace_entities()
+    xray_recorder.begin_segment('name')
+    yield
+    xray_recorder.clear_trace_entities()
+
+
+def test_ok():
+    status_code = 200
+    url = 'http://{}/status/{}'.format(BASE_URL, status_code)
+    requests.get(url)
+    subsegment = xray_recorder.current_segment().subsegments[0]
+    assert subsegment.name == url
+
+    http_meta = subsegment.http
+    assert http_meta['request']['url'] == url
+    assert http_meta['request']['method'].upper() == 'GET'
+    assert http_meta['response']['status'] == status_code
+
+
+def test_error():
+    status_code = 400
+    url = 'http://{}/status/{}'.format(BASE_URL, status_code)
+    requests.post(url)
+    subsegment = xray_recorder.current_segment().subsegments[0]
+    assert subsegment.name == url
+    assert subsegment.error
+
+    http_meta = subsegment.http
+    assert http_meta['request']['url'] == url
+    assert http_meta['request']['method'].upper() == 'POST'
+    assert http_meta['response']['status'] == status_code
+
+
+def test_throttle():
+    status_code = 429
+    url = 'http://{}/status/{}'.format(BASE_URL, status_code)
+    requests.head(url)
+    subsegment = xray_recorder.current_segment().subsegments[0]
+    assert subsegment.name == url
+    assert subsegment.error
+    assert subsegment.throttle
+
+    http_meta = subsegment.http
+    assert http_meta['request']['url'] == url
+    assert http_meta['request']['method'].upper() == 'HEAD'
+    assert http_meta['response']['status'] == status_code
+
+
+def test_fault():
+    status_code = 500
+    url = 'http://{}/status/{}'.format(BASE_URL, status_code)
+    requests.put(url)
+    subsegment = xray_recorder.current_segment().subsegments[0]
+    assert subsegment.name == url
+    assert subsegment.fault
+
+    http_meta = subsegment.http
+    assert http_meta['request']['url'] == url
+    assert http_meta['request']['method'].upper() == 'PUT'
+    assert http_meta['response']['status'] == status_code
+
+
+def test_invalid_url():
+    try:
+        requests.get('http://doesnt.exist')
+    except Exception:
+        # prevent uncatch exception from breaking test run
+        pass
+    subsegment = xray_recorder.current_segment().subsegments[0]
+    assert subsegment.fault
+
+    exception = subsegment.cause['exceptions'][0]
+    assert exception.type == 'ConnectionError'

--- a/tests/ext/httplib/test_httplib.py
+++ b/tests/ext/httplib/test_httplib.py
@@ -4,7 +4,7 @@ import sys
 from aws_xray_sdk.core import patch
 from aws_xray_sdk.core import xray_recorder
 from aws_xray_sdk.core.context import Context
-from aws_xray_sdk.ext.util import _strip_url
+from aws_xray_sdk.ext.util import strip_url
 
 if sys.version_info >= (3, 0, 0):
     import http.client as httplib
@@ -51,7 +51,7 @@ def test_ok():
     url = 'http://{}/status/{}?foo=bar&baz=foo'.format(BASE_URL, status_code)
     _do_req(url)
     subsegment = xray_recorder.current_segment().subsegments[1]
-    assert subsegment.name == _strip_url(url)
+    assert subsegment.name == strip_url(url)
 
     http_meta = subsegment.http
     assert http_meta['request']['url'] == url

--- a/tests/ext/httplib/test_httplib.py
+++ b/tests/ext/httplib/test_httplib.py
@@ -30,7 +30,7 @@ def test_ok():
     status_code = 200
     url = 'http://{}/status/{}'.format(BASE_URL, status_code)
     requests.get(url)
-    subsegment = xray_recorder.current_segment().subsegments[0]
+    subsegment = xray_recorder.current_segment().subsegments[1]
     assert subsegment.name == url
 
     http_meta = subsegment.http
@@ -43,7 +43,7 @@ def test_error():
     status_code = 400
     url = 'http://{}/status/{}'.format(BASE_URL, status_code)
     requests.post(url)
-    subsegment = xray_recorder.current_segment().subsegments[0]
+    subsegment = xray_recorder.current_segment().subsegments[1]
     assert subsegment.name == url
     assert subsegment.error
 
@@ -57,7 +57,7 @@ def test_throttle():
     status_code = 429
     url = 'http://{}/status/{}'.format(BASE_URL, status_code)
     requests.head(url)
-    subsegment = xray_recorder.current_segment().subsegments[0]
+    subsegment = xray_recorder.current_segment().subsegments[1]
     assert subsegment.name == url
     assert subsegment.error
     assert subsegment.throttle
@@ -72,7 +72,7 @@ def test_fault():
     status_code = 500
     url = 'http://{}/status/{}'.format(BASE_URL, status_code)
     requests.put(url)
-    subsegment = xray_recorder.current_segment().subsegments[0]
+    subsegment = xray_recorder.current_segment().subsegments[1]
     assert subsegment.name == url
     assert subsegment.fault
 
@@ -92,4 +92,4 @@ def test_invalid_url():
     assert subsegment.fault
 
     exception = subsegment.cause['exceptions'][0]
-    assert exception.type == 'ConnectionError'
+    assert exception.type == 'NewConnectionError'

--- a/tests/ext/httplib/test_httplib.py
+++ b/tests/ext/httplib/test_httplib.py
@@ -28,7 +28,7 @@ def construct_ctx():
 
 def test_ok():
     status_code = 200
-    url = 'http://{}/status/{}'.format(BASE_URL, status_code)
+    url = 'http://{}/status/{}?foo=bar&baz=foo'.format(BASE_URL, status_code)
     requests.get(url)
     subsegment = xray_recorder.current_segment().subsegments[1]
     assert subsegment.name == url

--- a/tests/ext/httplib/test_httplib.py
+++ b/tests/ext/httplib/test_httplib.py
@@ -1,9 +1,17 @@
 import pytest
-import requests
+import sys
 
 from aws_xray_sdk.core import patch
 from aws_xray_sdk.core import xray_recorder
 from aws_xray_sdk.core.context import Context
+from aws_xray_sdk.ext.util import _strip_url
+
+if sys.version_info >= (3, 0, 0):
+    import http.client as httplib
+    from urllib.parse import urlparse
+else:
+    import httplib
+    from urlparse import urlparse
 
 
 patch(('httplib',))
@@ -26,12 +34,24 @@ def construct_ctx():
     xray_recorder.clear_trace_entities()
 
 
+def _do_req(url, method='GET'):
+    parts = urlparse(url)
+    host, _, port = parts.netloc.partition(':')
+    if port == '':
+        port = None
+    conn = httplib.HTTPConnection(parts.netloc, port)
+
+    path = '{}?{}'.format(parts.path, parts.query) if parts.query else parts.path
+    conn.request(method, path)
+    resp = conn.getresponse()
+
+
 def test_ok():
     status_code = 200
     url = 'http://{}/status/{}?foo=bar&baz=foo'.format(BASE_URL, status_code)
-    requests.get(url)
+    _do_req(url)
     subsegment = xray_recorder.current_segment().subsegments[1]
-    assert subsegment.name == url
+    assert subsegment.name == _strip_url(url)
 
     http_meta = subsegment.http
     assert http_meta['request']['url'] == url
@@ -42,7 +62,7 @@ def test_ok():
 def test_error():
     status_code = 400
     url = 'http://{}/status/{}'.format(BASE_URL, status_code)
-    requests.post(url)
+    _do_req(url, 'POST')
     subsegment = xray_recorder.current_segment().subsegments[1]
     assert subsegment.name == url
     assert subsegment.error
@@ -56,7 +76,7 @@ def test_error():
 def test_throttle():
     status_code = 429
     url = 'http://{}/status/{}'.format(BASE_URL, status_code)
-    requests.head(url)
+    _do_req(url, 'HEAD')
     subsegment = xray_recorder.current_segment().subsegments[1]
     assert subsegment.name == url
     assert subsegment.error
@@ -71,7 +91,7 @@ def test_throttle():
 def test_fault():
     status_code = 500
     url = 'http://{}/status/{}'.format(BASE_URL, status_code)
-    requests.put(url)
+    _do_req(url, 'PUT')
     subsegment = xray_recorder.current_segment().subsegments[1]
     assert subsegment.name == url
     assert subsegment.fault
@@ -84,7 +104,7 @@ def test_fault():
 
 def test_invalid_url():
     try:
-        requests.get('http://doesnt.exist')
+        _do_req('http://doesnt.exist')
     except Exception:
         # prevent uncatch exception from breaking test run
         pass
@@ -92,4 +112,4 @@ def test_invalid_url():
     assert subsegment.fault
 
     exception = subsegment.cause['exceptions'][0]
-    assert exception.type == 'NewConnectionError'
+    assert exception.type == 'gaierror'

--- a/tests/ext/requests/test_requests.py
+++ b/tests/ext/requests/test_requests.py
@@ -4,6 +4,7 @@ import requests
 from aws_xray_sdk.core import patch
 from aws_xray_sdk.core import xray_recorder
 from aws_xray_sdk.core.context import Context
+from aws_xray_sdk.ext.util import _strip_url
 
 
 patch(('requests',))
@@ -31,7 +32,7 @@ def test_ok():
     url = 'http://{}/status/{}?foo=bar'.format(BASE_URL, status_code)
     requests.get(url)
     subsegment = xray_recorder.current_segment().subsegments[0]
-    assert subsegment.name == url
+    assert subsegment.name == _strip_url(url)
 
     http_meta = subsegment.http
     assert http_meta['request']['url'] == url

--- a/tests/ext/requests/test_requests.py
+++ b/tests/ext/requests/test_requests.py
@@ -28,7 +28,7 @@ def construct_ctx():
 
 def test_ok():
     status_code = 200
-    url = 'http://{}/status/{}'.format(BASE_URL, status_code)
+    url = 'http://{}/status/{}?foo=bar'.format(BASE_URL, status_code)
     requests.get(url)
     subsegment = xray_recorder.current_segment().subsegments[0]
     assert subsegment.name == url

--- a/tests/ext/requests/test_requests.py
+++ b/tests/ext/requests/test_requests.py
@@ -4,7 +4,7 @@ import requests
 from aws_xray_sdk.core import patch
 from aws_xray_sdk.core import xray_recorder
 from aws_xray_sdk.core.context import Context
-from aws_xray_sdk.ext.util import _strip_url
+from aws_xray_sdk.ext.util import strip_url
 
 
 patch(('requests',))
@@ -32,7 +32,7 @@ def test_ok():
     url = 'http://{}/status/{}?foo=bar'.format(BASE_URL, status_code)
     requests.get(url)
     subsegment = xray_recorder.current_segment().subsegments[0]
-    assert subsegment.name == _strip_url(url)
+    assert subsegment.name == strip_url(url)
 
     http_meta = subsegment.http
     assert http_meta['request']['url'] == url


### PR DESCRIPTION
This is what we're going to use in production.  It's important for tracing things like the old google API, which uses httplib2 which uses httplib.

NOTE: perhaps this should replace the requests patch as requests uses httplib

fixes: https://github.com/aws/aws-xray-sdk-python/issues/20