### PR TITLE
Filter invalid characters from annotation key names; raise warning if found

### DIFF
--- a/aws_xray_sdk/core/models/entity.py
+++ b/aws_xray_sdk/core/models/entity.py
@@ -16,6 +16,7 @@ log = logging.getLogger(__name__)
 
 # List of valid characters found at http://docs.aws.amazon.com/xray/latest/devguide/xray-api-segmentdocuments.html
 _valid_name_characters = string.ascii_letters + string.digits + '_.:/%&#=+\-@ '
+_valid_annotation_key_characters = string.ascii_letters + string.digits + '_'
 
 
 class Entity(object):
@@ -140,7 +141,12 @@ class Entity(object):
             log.warning("ignoring unsupported annotation value type %s.", type(value))
             return
 
-        self.annotations[key] = value
+        sanitized_key = ''.join([c for c in key if c in _valid_annotation_key_characters])
+        
+        if sanitized_key != key:
+            log.warning("ignoring unsupported characters in annotation key %s", key)
+
+        self.annotations[sanitized_key] = value
 
     def put_metadata(self, key, value, namespace='default'):
         """

--- a/docs/basic.rst
+++ b/docs/basic.rst
@@ -51,7 +51,8 @@ You can add annotations and metadata to an active segment/subsegment.
 Annotations are simple key-value pairs that are indexed for use with
 `filter expressions <http://docs.aws.amazon.com/xray/latest/devguide/xray-console-filters.html>`_.
 Use annotations to record data that you want to use to group traces in the console,
-or when calling the GetTraceSummaries API.
+or when calling the GetTraceSummaries API. Annotation keys may only use ASCII letters and the underscore(_)
+character.
 
 Metadata are key-value pairs with values of any type, including objects and lists, but that are not indexed.
 Use metadata to record data you want to store in the trace but don't need to use for searching traces.


### PR DESCRIPTION
Fixes #18 

I took the approach of stripping invalid characters from annotation key names and raising a warning, rather than exiting the function.