### PR TITLE
Fix http.URL field segment for Aiohttp extension

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,8 @@ unreleased
 ==========
 * feature: Use the official middleware pattern for Aiohttp ext. `PR29 <https://github.com/aws/aws-xray-sdk-python/pull/29>`_.
 * bugfix: SQLAlcemy plugin would cause warning messages with some db connection strings that contained invalid characters for a segment/subsegment name.
+* bugfix: Aiohttp middleware serialized URL values incorrectly `PR37 <https://github.com/aws/aws-xray-sdk-python/pull/37>`_
+
 0.96
 ====
 * feature: Add support for SQLAlchemy and Flask-SQLAlcemy. `PR14 <https://github.com/aws/aws-xray-sdk-python/pull/14>`_.

--- a/aws_xray_sdk/ext/aiohttp/middleware.py
+++ b/aws_xray_sdk/ext/aiohttp/middleware.py
@@ -36,7 +36,7 @@ async def middleware(request, handler):
     )
 
     # Store request metadata in the current segment
-    segment.put_http_meta(http.URL, request.url)
+    segment.put_http_meta(http.URL, str(request.url))
     segment.put_http_meta(http.METHOD, request.method)
 
     if 'User-Agent' in request.headers:

--- a/tests/ext/aiohttp/test_aiohttp.py
+++ b/tests/ext/aiohttp/test_aiohttp.py
@@ -119,9 +119,7 @@ async def test_ok(test_client, loop, recorder):
     response = segment.http['response']
 
     assert request['method'] == 'GET'
-    assert str(request['url']).startswith('http://127.0.0.1')
-    assert request['url'].host == '127.0.0.1'
-    assert request['url'].path == '/'
+    assert request['url'] == 'http://127.0.0.1:{port}/'.format(port=client.port)
     assert response['status'] == 200
 
 
@@ -145,8 +143,7 @@ async def test_error(test_client, loop, recorder):
     request = segment.http['request']
     response = segment.http['response']
     assert request['method'] == 'GET'
-    assert request['url'].host == '127.0.0.1'
-    assert request['url'].path == '/error'
+    assert request['url'] == 'http://127.0.0.1:{port}/error'.format(port=client.port)
     assert request['client_ip'] == '127.0.0.1'
     assert response['status'] == 404
 
@@ -172,8 +169,7 @@ async def test_exception(test_client, loop, recorder):
     response = segment.http['response']
     exception = segment.cause['exceptions'][0]
     assert request['method'] == 'GET'
-    assert request['url'].host == '127.0.0.1'
-    assert request['url'].path == '/exception'
+    assert request['url'] == 'http://127.0.0.1:{port}/exception'.format(port=client.port)
     assert request['client_ip'] == '127.0.0.1'
     assert response['status'] == 500
     assert exception.type == 'KeyError'


### PR DESCRIPTION
Current implementation sends an invalid payload for the URL segment field once is serialized. The following snippet shows the output that is sent:

```bash
{"end_time": 1520921976.0243928, "http": {"request": {"client_ip": "127.0.0.1", "method": "GET", "url": [["http", "localhost:5000", "/operations/healthcheck", "", ""]], "user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.186 Safari/537.36"}, "response": {"status": 200}}, "id": "713f9e1ef69bce80", "in_progress": false, "name": "test", "start_time": 1520921976.023138, "trace_id": "1-5aa76d78-99ea86b4976213b1548fb9ae"} to xray:2000.
```

The serializer tries to serialize the URL object that is not a string is basically a YARL object, so having as an output this weird ```[["http", "localhost:5000", "/operations/healthcheck", "", ""]]``` value that is not well interpreted by the AWS Console.

The fix basically castes the field to a string and test properly this casting, having an alignment with other implementations such as the Flask one.   