### PR TITLE
Recorder.configure: don't overwrite plugins unless specified

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,8 @@ unreleased
 ==========
 * feature: Use the official middleware pattern for Aiohttp ext. `PR29 <https://github.com/aws/aws-xray-sdk-python/pull/29>`_.
 * bugfix: SQLAlcemy plugin would cause warning messages with some db connection strings that contained invalid characters for a segment/subsegment name.
-* bugfix: Aiohttp middleware serialized URL values incorrectly `PR37 <https://github.com/aws/aws-xray-sdk-python/pull/37>`_
+* bugfix: Aiohttp middleware serialized URL values incorrectly. `PR37 <https://github.com/aws/aws-xray-sdk-python/pull/37>`_
+* bugfix: Don't overwrite plugins list on each `.configure` call. `PR38 <https://github.com/aws/aws-xray-sdk-python/pull/38>`_
 
 0.96
 ====

--- a/aws_xray_sdk/core/recorder.py
+++ b/aws_xray_sdk/core/recorder.py
@@ -73,6 +73,8 @@ class AWSXRayRecorder(object):
         :param tuple plugins: plugins that add extra metadata to each segment.
             Currently available plugins are EC2Plugin, ECS plugin and
             ElasticBeanstalkPlugin.
+            If you want to disable all previously enabled plugins,
+            pass an empty tuple ``()``.
         :param str context_missing: recorder behavior when it tries to mutate
             a segment or add a subsegment but there is no active segment.
             RUNTIME_ERROR means the recorder will raise an exception.
@@ -117,12 +119,13 @@ class AWSXRayRecorder(object):
         if streaming_threshold:
             self.streaming_threshold = streaming_threshold
 
-        plugin_modules = None
-        if plugins:
-            plugin_modules = get_plugin_modules(plugins)
-            for module in plugin_modules:
-                module.initialize()
-        self._plugins = plugin_modules
+        if plugins is not None:
+            plugin_modules = None
+            if plugins:
+                plugin_modules = get_plugin_modules(plugins)
+                for module in plugin_modules:
+                    module.initialize()
+            self._plugins = plugin_modules
 
     def begin_segment(self, name=None, traceid=None,
                       parent_id=None, sampling=None):


### PR DESCRIPTION
With most options, Recorder.configure() doesn't touch the value if corresponding option is not passed.
But with `plugins` option behaviour is different: it is updated every time you call `configure`.
So this code won't work correctly:

    xray_recorder.configure(plugins=('EC2Plugin', 'ECS'))
    ...
    xray_recorder.configure(context=MyContext())  # this resets plugins

This patch will fix that behaviour: now in order to explicitly reset plugins, you will need to pass an empty tuple to `configure`;
if `plugins is None` then plugin list won't be changed.