### PR TITLE
Handle Middleware closing segment before we end all subsegments in sqlalchemy.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,7 @@ unreleased
 * feature: Use the official middleware pattern for Aiohttp ext. `PR29 <https://github.com/aws/aws-xray-sdk-python/pull/29>`_.
 * bugfix: SQLAlcemy plugin would cause warning messages with some db connection strings that contained invalid characters for a segment/subsegment name.
 * bugfix: Aiohttp middleware serialized URL values incorrectly `PR37 <https://github.com/aws/aws-xray-sdk-python/pull/37>`_
+* bugfix: SQLAlchemy could try and end subsegments, eg. sqlalchemy.orm.session.flush,  after the Flask middleware closed the parent segment. Catch this exception so not to break users apps.
 
 0.96
 ====


### PR DESCRIPTION
In some cases the Flask Middleware closes the segment before we call sqlalchemy.orm.session.flush which results in an AlreadyEndedException exception. This patch catches the exception, logs a debug message and moves on, allowing the Flask app to finish processing.  