### PR TITLE
Fix LambdaContext.put_subsegment() with no current entity

### DIFF
--- a/aws_xray_sdk/core/lambda_launcher.py
+++ b/aws_xray_sdk/core/lambda_launcher.py
@@ -72,6 +72,7 @@ class LambdaContext(Context):
 
         if not self._is_subsegment(current_entity) and current_entity.initializing:
             log.warning("Subsegment %s discarded due to Lambda worker still initializing" % subsegment.name)
+            return
 
         current_entity.add_subsegment(subsegment)
         self._local.entities.append(subsegment)


### PR DESCRIPTION
put_subsegment logs a warning about subsegment being discarded but then still tries to add it.
`if not self._is_subsegment` might mean that `current_entity` is `None`, in such case code below will result in AttributeError.
Looks like the warning should be followed by `return` statement.