### PR TITLE
Fix invalid aiohttp import

### DIFF
--- a/aws_xray_sdk/ext/aiohttp/middleware.py
+++ b/aws_xray_sdk/ext/aiohttp/middleware.py
@@ -1,15 +1,15 @@
 """
 AioHttp Middleware
 """
-import aiohttp
 import traceback
+from aiohttp import web
 
 from aws_xray_sdk.core import xray_recorder
 from aws_xray_sdk.core.models import http
 from aws_xray_sdk.ext.util import calculate_sampling_decision, calculate_segment_name, construct_xray_header
 
 
-@aiohttp.web.middleware
+@web.middleware
 async def middleware(request, handler):
     """
     Main middleware function, deals with all the X-Ray segment logic


### PR DESCRIPTION
A silly bug was introduced because of #29, for an unknown reason the test suit didn't detect that issue.

The `web` submodule is not automatically imported by `aiohttp` when we make the typical `import aiohttp`, we have to import it explicitly.