### PR TITLE
Allow standalone sqlalchemy integrations without flask_sqlalchemy

### DIFF
--- a/aws_xray_sdk/ext/sqlalchemy/util/decorators.py
+++ b/aws_xray_sdk/ext/sqlalchemy/util/decorators.py
@@ -25,7 +25,12 @@ def decorate_all_functions(function_decorator):
 def xray_on_call(cls, func):
     def wrapper(*args, **kw):
         from ..query import XRayQuery, XRaySession
-        from ...flask_sqlalchemy.query import XRaySignallingSession
+        try:
+            from ...flask_sqlalchemy.query import XRaySignallingSession
+            has_sql_alchemy = True
+        except ImportError:
+            has_sql_alchemy = False
+
         class_name = str(cls.__module__)
         c = xray_recorder._context
         sql = None
@@ -34,7 +39,7 @@ def xray_on_call(cls, func):
             for arg in args:
                 if isinstance(arg, XRaySession):
                     sql = parse_bind(arg.bind)
-                if isinstance(arg, XRaySignallingSession):
+                if has_sql_alchemy and isinstance(arg, XRaySignallingSession):
                     sql = parse_bind(arg.bind)
         if class_name == 'sqlalchemy.orm.query':
             for arg in args:


### PR DESCRIPTION
*Description of changes:* This pull request allow the integration of the library in "pure" sqlalchemy projects (without flask_sqlalchemy).

Current version of the library tries to import flask_sqlalchemy even though it is possible to do the same without such dependency. This pull request fix this issue while still behaving exactly in the same way when flask_sqlalchemy is installed.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
