### PR TITLE
Handle missing subsegment when rendering a Django template

### DIFF
--- a/aws_xray_sdk/ext/django/templates.py
+++ b/aws_xray_sdk/ext/django/templates.py
@@ -23,7 +23,8 @@ def patch_template():
         if template_name:
             name = str(template_name)
             subsegment = xray_recorder.current_subsegment()
-            subsegment.name = name
+            if subsegment:
+                subsegment.name = name
 
         return Template._xray_original_render(self, context)
 


### PR DESCRIPTION
*Description of changes:*
If I render a template without having a current segment (eg. when executing a test case), then we get an error when we try to update the name of the nonexistent subsegment.

In other places we deal with this scenario by checking for an empty subsegment, which makes sense - ideally, tracing should fail silently. This change brings the Django template rendering interceptor inline with that practice.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
