### PR TITLE
Give up when there is no open segment and LOG_ERROR is configured

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ CHANGELOG
 unreleased
 ==========
 * feature: Added Sqlalchemy parameterized query capture. `PR34 <https://github.com/aws/aws-xray-sdk-python/pull/34>`_.
+* bugfix: Added new `raise_if_not_subsegment` parameter for Aiohttp Client tracing `PR58 <https://github.com/aws/aws-xray-sdk-python/pull/58>`_.
 
 1.0
 ===

--- a/tests/ext/aiohttp/test_client.py
+++ b/tests/ext/aiohttp/test_client.py
@@ -134,6 +134,7 @@ async def test_invalid_url(loop, recorder):
 
 
 async def test_no_segment_raise(loop, recorder):
+    xray_recorder.configure(context_missing='RUNTIME_ERROR')
     trace_config = aws_xray_trace_config()
     status_code = 200
     url = 'http://{}/status/{}?foo=bar'.format(BASE_URL, status_code)
@@ -144,7 +145,8 @@ async def test_no_segment_raise(loop, recorder):
 
 
 async def test_no_segment_not_raise(loop, recorder):
-    trace_config = aws_xray_trace_config(raise_if_not_subsegment=False)
+    xray_recorder.configure(context_missing='LOG_ERROR')
+    trace_config = aws_xray_trace_config()
     status_code = 200
     url = 'http://{}/status/{}?foo=bar'.format(BASE_URL, status_code)
     async with ClientSession(loop=loop, trace_configs=[trace_config]) as session:


### PR DESCRIPTION
Without setting this flag as False, any HTTP call done with the Aiohttp
Client when there is no an active segment will fail with the
SegmentNotFoundException exception.

This issue can be annoying for this systems that do not create
explicitly the segements and relay on the sampled incomming requests,
which create automatically segments just for a sub set of the incomming
request.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
