### PR TITLE
Improve recorded detail of stacktraces

### DIFF
--- a/aws_xray_sdk/core/async_recorder.py
+++ b/aws_xray_sdk/core/async_recorder.py
@@ -1,9 +1,9 @@
 import time
-import traceback
 
 import wrapt
 
 from aws_xray_sdk.core.recorder import AWSXRayRecorder
+from aws_xray_sdk.core.utils import stacktrace
 
 
 class AsyncAWSXRayRecorder(AWSXRayRecorder):
@@ -47,7 +47,7 @@ class AsyncAWSXRayRecorder(AWSXRayRecorder):
             return return_value
         except Exception as e:
             exception = e
-            stack = traceback.extract_stack(limit=self._max_trace_back)
+            stack = stacktrace.get_stacktrace(limit=self._max_trace_back)
             raise
         finally:
             # No-op if subsegment is `None` due to `LOG_ERROR`.

--- a/aws_xray_sdk/core/recorder.py
+++ b/aws_xray_sdk/core/recorder.py
@@ -4,7 +4,6 @@ import logging
 import os
 import platform
 import time
-import traceback
 
 import wrapt
 
@@ -23,6 +22,7 @@ from .plugins.utils import get_plugin_modules
 from .lambda_launcher import check_in_lambda
 from .exceptions.exceptions import SegmentNameMissingException
 from .utils.compat import string_types
+from .utils import stacktrace
 
 log = logging.getLogger(__name__)
 
@@ -398,7 +398,7 @@ class AWSXRayRecorder(object):
             return return_value
         except Exception as e:
             exception = e
-            stack = traceback.extract_stack(limit=self.max_trace_back)
+            stack = stacktrace.get_stacktrace(limit=self.max_trace_back)
             raise
         finally:
             # No-op if subsegment is `None` due to `LOG_ERROR`.

--- a/aws_xray_sdk/core/utils/stacktrace.py
+++ b/aws_xray_sdk/core/utils/stacktrace.py
@@ -1,0 +1,51 @@
+import sys
+import traceback
+
+
+def get_stacktrace(limit=None):
+    """
+    Get a full stacktrace for the current state of execution.
+
+    Include the current state of the stack, minus this function.
+    If there is an active exception, include the stacktrace information from
+    the exception as well.
+
+    :param int limit:
+        Optionally limit stack trace size results. This parmaeters has the same
+        meaning as the `limit` parameter in `traceback.print_stack`.
+    :returns:
+        List of stack trace objects, in the same form as
+        `traceback.extract_stack`.
+    """
+    if limit is not None and limit == 0:
+        # Nothing to return. This is consistent with the behavior of the
+        # functions in the `traceback` module.
+        return []
+
+    stack = traceback.extract_stack()
+    # Remove this `get_stacktrace()` function call from the stack info.
+    # For what we want to report, this is superfluous information and arguably
+    # adds garbage to the report.
+    # Also drop the `traceback.extract_stack()` call above from the returned
+    # stack info, since this is also superfluous.
+    stack = stack[:-2]
+
+    _exc_type, _exc, exc_traceback = sys.exc_info()
+    if exc_traceback is not None:
+        # If and only if there is a currently triggered exception, combine the
+        # exception traceback information with the current stack state to get a
+        # complete trace.
+        exc_stack = traceback.extract_tb(exc_traceback)
+        stack += exc_stack
+
+    # Limit the stack trace size, if a limit was specified:
+    if limit is not None:
+        # Copy the behavior of `traceback` functions with a `limit` argument.
+        # See https://docs.python.org/3/library/traceback.html.
+        if limit > 0:
+            # limit > 0: include the last `limit` items
+            stack = stack[-limit:]
+        else:
+            # limit < 0: include the first `abs(limit)` items
+            stack = stack[:abs(limit)]
+    return stack

--- a/aws_xray_sdk/ext/aiohttp/client.py
+++ b/aws_xray_sdk/ext/aiohttp/client.py
@@ -2,12 +2,12 @@
 AioHttp Client tracing, only compatible with Aiohttp 3.X versions
 """
 import aiohttp
-import traceback
 
 from types import SimpleNamespace
 
 from aws_xray_sdk.core import xray_recorder
 from aws_xray_sdk.core.models import http
+from aws_xray_sdk.core.utils import stacktrace
 from aws_xray_sdk.ext.util import inject_trace_header, strip_url
 
 # All aiohttp calls will entail outgoing HTTP requests, only in some ad-hoc
@@ -51,7 +51,7 @@ async def end_subsegment_with_exception(session, trace_config_ctx, params):
     subsegment = xray_recorder.current_subsegment()
     subsegment.add_exception(
         params.exception,
-        traceback.extract_stack(limit=xray_recorder._max_trace_back)
+        stacktrace.get_stacktrace(limit=xray_recorder._max_trace_back)
     )
 
     if isinstance(params.exception, LOCAL_EXCEPTIONS):

--- a/aws_xray_sdk/ext/aiohttp/middleware.py
+++ b/aws_xray_sdk/ext/aiohttp/middleware.py
@@ -1,12 +1,12 @@
 """
 AioHttp Middleware
 """
-import traceback
 from aiohttp import web
 from aiohttp.web_exceptions import HTTPException
 
 from aws_xray_sdk.core import xray_recorder
 from aws_xray_sdk.core.models import http
+from aws_xray_sdk.core.utils import stacktrace
 from aws_xray_sdk.ext.util import calculate_sampling_decision, \
     calculate_segment_name, construct_xray_header, prepare_response_header
 
@@ -69,7 +69,7 @@ async def middleware(request, handler):
         # Store exception information including the stacktrace to the segment
         response = None
         segment.put_http_meta(http.STATUS, 500)
-        stack = traceback.extract_stack(limit=xray_recorder.max_trace_back)
+        stack = stacktrace.get_stacktrace(limit=xray_recorder.max_trace_back)
         segment.add_exception(err, stack)
         raise
     finally:

--- a/aws_xray_sdk/ext/django/middleware.py
+++ b/aws_xray_sdk/ext/django/middleware.py
@@ -1,8 +1,8 @@
 import logging
-import traceback
 
 from aws_xray_sdk.core import xray_recorder
 from aws_xray_sdk.core.models import http
+from aws_xray_sdk.core.utils import stacktrace
 from aws_xray_sdk.ext.util import calculate_sampling_decision, \
     calculate_segment_name, construct_xray_header, prepare_response_header
 
@@ -87,5 +87,5 @@ class XRayMiddleware(object):
         segment = xray_recorder.current_segment()
         segment.put_http_meta(http.STATUS, 500)
 
-        stack = traceback.extract_stack(limit=xray_recorder._max_trace_back)
+        stack = stacktrace.get_stacktrace(limit=xray_recorder._max_trace_back)
         segment.add_exception(exception, stack)

--- a/aws_xray_sdk/ext/flask/middleware.py
+++ b/aws_xray_sdk/ext/flask/middleware.py
@@ -1,9 +1,8 @@
-import traceback
-
 import flask.templating
 from flask import request
 
 from aws_xray_sdk.core.models import http
+from aws_xray_sdk.core.utils import stacktrace
 from aws_xray_sdk.ext.util import calculate_sampling_decision, \
     calculate_segment_name, construct_xray_header, prepare_response_header
 
@@ -86,7 +85,7 @@ class XRayMiddleware(object):
             return
 
         segment.put_http_meta(http.STATUS, 500)
-        stack = traceback.extract_stack(limit=self._recorder._max_trace_back)
+        stack = stacktrace.get_stacktrace(limit=self._recorder._max_trace_back)
         segment.add_exception(exception, stack)
         self._recorder.end_segment()
 


### PR DESCRIPTION
In many X-Ray SDK use cases, including the Django/Flask middleware and
aws_xray_sdk.core.xray_recorder.capture and .capture_async cases, there
is a broad try/except "catch-all" for exceptions which records useful
information in an X-Ray trace in the event of an unexpected exception.

However, the approach (prior to this patch) of using
`traceback.extract_stack` in the `except` block to extract stack trace
information isn't terribly useful when viewing X-Ray traces for
debugging purposes. `traceback.extract_stack` only shows the stack state
up to and including the `traceback.extract_stack` call in the `except`
block; it does not include the stack trace information from the caught
exception--which are arguably the most important details to include in
the X-Ray trace! Similarly, including _only_ the exception's stack trace
information can omit important code path context if the
exeception-producing code is wrapped in a decorator. This is a very
subtle but important detail. There is a good discussion of exactly this
problem--specificaly in the context of decorators with a "catch-all"
try/except--on Stackoverflow:
https://stackoverflow.com/questions/14527819/traceback-shows-up-until-decorator.

*Description of changes:*

This patch introduces the `stacktrace` utility module and is an attempt
to include more relevant info in recorded X-Ray traces while respecting
the `max_trace_back` behavior expressed in many places to avoid bloated
trace messages.

To illustrate the difference this makes, consider a trivial Lambda function written in Python:

```python
from aws_xray_sdk.core import xray_recorder 
                                            
                                            
@xray_recorder.capture('handler')           
def handler(event, context):                
    data = foo()                            
    return data                             
                                            
                                            
def foo():                                  
    return bar()                            
                                            
                                                                                   
def bar():                                  
    raise Exception('Something went wrong!')
    return {'data': [1,2,3]}
```

There are multiple function calls here in order to create an interesting call stack for tracing purposes. To test this function, I've simply built a function zip with the appropriate version of the X-Ray SDK and invoked the function with `lambda:Invoke`.

With the current implementation of `aws_xray_sdk`, here's the trace that gets recorded by X-Ray:

<img width="556" alt="before-trace" src="https://user-images.githubusercontent.com/464394/45025956-398f8200-b03d-11e8-81d7-828f2568a679.png">

```
Exception: Something went wrong!
at <module> (bootstrap.py:538)
at main (bootstrap.py:533)
at handle_event_request (bootstrap.py:250) 
```

With this patch applied, we get a lot more information about the call stack, as we would expect:

<img width="561" alt="after-trace" src="https://user-images.githubusercontent.com/464394/45026003-5035d900-b03d-11e8-936a-b6c3906cfa80.png">

```
Exception: Something went wrong!
at <module> (bootstrap.py:538)
at main (bootstrap.py:533)
at handle_event_request (bootstrap.py:250)
at handler (myfunction.py:6)
at foo (myfunction.py:11)
at bar (myfunction.py:15)
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

---

I'm not sure how best to test this (since stack information is very runtime-specific) so ideas are welcome. My patch also assumes that this fix applies the original intended behavior so it _shouldn't_ be too controversial, but I'm naturally happy to discuss and attempt alternative solutions. Please let me know if the problem I've described above isn't clear.