### PR TITLE
Default Sampler sampling_req to None

### DIFF
--- a/aws_xray_sdk/core/sampling/sampler.py
+++ b/aws_xray_sdk/core/sampling/sampler.py
@@ -43,7 +43,7 @@ class DefaultSampler(object):
                 self._target_poller.start()
                 self._started = True
 
-    def should_trace(self, sampling_req):
+    def should_trace(self, sampling_req=None):
         """
         Return the matched sampling rule name if the sampler finds one
         and decide to sample. If no sampling rule matched, it falls back


### PR DESCRIPTION
Issue #81 

*Description of changes:*

Currently, `sampling_req` is a required argument for `DefaultSampler.should_trace`. This results in an exception when `AWSXRayRecorder.begin_segment` invokes the sampler's `should_trace` without any arguments.

This change defaults `sampling_req` to None, which allows the downstream None checks to properly handle this case.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
