### PR TITLE
Support pynamodb

### DIFF
--- a/aws_xray_sdk/core/patcher.py
+++ b/aws_xray_sdk/core/patcher.py
@@ -5,6 +5,7 @@ log = logging.getLogger(__name__)
 
 SUPPORTED_MODULES = (
     'botocore',
+    'pynamodb',
     'requests',
     'sqlite3',
     'mysql',
@@ -15,6 +16,7 @@ SUPPORTED_MODULES = (
 
 NO_DOUBLE_PATCH = (
     'botocore',
+    'pynamodb',
     'requests',
     'sqlite3',
     'mysql',
@@ -42,9 +44,9 @@ def patch(modules_to_patch, raise_errors=True):
         # elif module_to_patch == 'aioboto3':
         #     modules.add('aiobotocore')
         # pynamodb requires botocore to be patched as well
-        # elif module_to_patch == 'pynamodb':
-        #     modules.add('botocore')
-        #     modules.add(module_to_patch)
+        elif module_to_patch == 'pynamodb':
+            modules.add('botocore')
+            modules.add(module_to_patch)
         else:
             modules.add(module_to_patch)
     unsupported_modules = modules - set(SUPPORTED_MODULES)

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@ deps =
     future
     # the sdk doesn't support earlier version of django
     django >= 1.10, <2.0
-    pynamodb
+    pynamodb >= 3.3.1
     psycopg2
     testing.postgresql
 
@@ -31,8 +31,8 @@ deps =
     py{35,36}: aiobotocore
 
 commands =
-    py{27,34}: coverage run --source aws_xray_sdk -m py.test tests --ignore tests/ext/aiohttp --ignore tests/ext/aiobotocore --ignore tests/test_async_local_storage.py --ignore tests/test_async_recorder.py --ignore tests/ext/pynamodb
-    py{35,36}: coverage run --source aws_xray_sdk -m py.test tests --ignore tests/ext/aiobotocore --ignore tests/ext/pynamodb
+    py{27,34}: coverage run --source aws_xray_sdk -m py.test tests --ignore tests/ext/aiohttp --ignore tests/ext/aiobotocore --ignore tests/test_async_local_storage.py --ignore tests/test_async_recorder.py
+    py{35,36}: coverage run --source aws_xray_sdk -m py.test tests --ignore tests/ext/aiobotocore
 
 setenv =
     DJANGO_SETTINGS_MODULE = tests.ext.django.app.settings


### PR DESCRIPTION
*Description of changes:*

Now `pynamodb >= 3.3.1` supports `botocore >= 1.11.3`. This PR supports pynamodb module again and a revert of changes in the commit https://github.com/aws/aws-xray-sdk-python/commit/beeb44574b99124b7ef620f32d1b0759fbd9a9e3 .

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
