### PR TITLE
Default sampling_req in LocalSampler to None

### DIFF
--- a/aws_xray_sdk/core/sampling/local/sampler.py
+++ b/aws_xray_sdk/core/sampling/local/sampler.py
@@ -50,7 +50,7 @@ class LocalSampler(object):
         self.load_local_rules(rules)
         self._random = Random()
 
-    def should_trace(self, sampling_req):
+    def should_trace(self, sampling_req=None):
         """
         Return True if the sampler decide to sample based on input
         information and sampling rules. It will first check if any


### PR DESCRIPTION
[AWSXRayRecorder.begin_segment](https://github.com/aws/aws-xray-sdk-python/blob/master/aws_xray_sdk/core/recorder.py#L208) was not passing `sampling_req` causing the following stacktrace when invoked inside of a lambda with all default sampling configurations

```json
{
  "errorMessage": "should_trace() missing 1 required positional argument: 'sampling_req'",
  "errorType": "TypeError",
  "stackTrace": [
    [
      "/var/task/app.py",
      60,
      "lambda_handler",
      "metadata={'api': {'event': event}}):"
    ],
    [
      "/var/task/app.py",
      16,
      "segment",
      "seg = xray_recorder.begin_segment(name)"
    ],
    [
      "/var/task/aws_xray_sdk/core/recorder.py",
      208,
      "begin_segment",
      "decision = self._sampler.should_trace()"
    ]
  ]
}
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
