### PR TITLE
Support dbname and database kwarg in psycopg2.connect()

### DIFF
--- a/tests/ext/psycopg2/test_psycopg2.py
+++ b/tests/ext/psycopg2/test_psycopg2.py
@@ -47,6 +47,32 @@ def test_execute_dsn_kwargs():
     assert sql['database_version']
 
 
+def test_execute_dsn_kwargs_alt_dbname():
+    """
+    Psycopg supports database to be passed as `database` or `dbname`
+    """
+    q = 'SELECT 1'
+
+    with testing.postgresql.Postgresql() as postgresql:
+        url = postgresql.url()
+        dsn = postgresql.dsn()
+        conn = psycopg2.connect(database=dsn['database'],
+                                user=dsn['user'],
+                                password='',
+                                host=dsn['host'],
+                                port=dsn['port'])
+        cur = conn.cursor()
+        cur.execute(q)
+
+    subsegment = xray_recorder.current_segment().subsegments[0]
+    assert subsegment.name == 'execute'
+    sql = subsegment.sql
+    assert sql['database_type'] == 'PostgreSQL'
+    assert sql['user'] == dsn['user']
+    assert sql['url'] == url
+    assert sql['database_version']
+
+
 def test_execute_dsn_string():
     q = 'SELECT 1'
     with testing.postgresql.Postgresql() as postgresql:


### PR DESCRIPTION
*Issue #90 

*Description of changes:
~~psycopg2.connect() Supports 3 variants of operation:~~
 1. ~~psycopg2.connect("dbname=test user=postgres password=secret")~~
 2. ~~psycopg2.connect(dbname="test", user="postgres", password="secret")~~
 3. ~~psycopg2.connect()~~

~~Previously we only supported 1 and 2. Now support variant 3 and mix of 2 and 3.~~

~~This change is not entierly backwards compatible previously the metadata used to
contain keys `url` and `user`. These are no longer exposed however the connection
parameters are available as `connection_string`. If this backward incompatibility
is not desirable then change can be made to extract values as they were before
using conn.dsn. However the URL will not be correct as password is mangled. It's
not clear to me if one option is clearly better than the other.~~


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
