### PR TITLE
Fix psycopg2 register type

### DIFF
--- a/tests/ext/psycopg2/test_psycopg2.py
+++ b/tests/ext/psycopg2/test_psycopg2.py
@@ -1,4 +1,5 @@
 import psycopg2
+import psycopg2.extras
 import psycopg2.pool
 
 import pytest
@@ -144,3 +145,16 @@ def test_execute_bad_query():
 
     exception = subsegment.cause['exceptions'][0]
     assert exception.type == 'ProgrammingError'
+
+
+def test_register_extensions():
+    with testing.postgresql.Postgresql() as postgresql:
+        url = postgresql.url()
+        dsn = postgresql.dsn()
+        conn = psycopg2.connect('dbname=' + dsn['database'] +
+                                ' password=mypassword' +
+                                ' host=' + dsn['host'] +
+                                ' port=' + str(dsn['port']) +
+                                ' user=' + dsn['user'])
+        assert psycopg2.extras.register_uuid(None, conn)
+        assert psycopg2.extras.register_uuid(None, conn.cursor())


### PR DESCRIPTION
This patch is intended to fix problems when you try to register extensions like uuid on psycopg2.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
