### PR TITLE
Segment / Subsegment / Recorder.capture context managers

### DIFF
--- a/aws_xray_sdk/core/models/subsegment.py
+++ b/aws_xray_sdk/core/models/subsegment.py
@@ -1,6 +1,8 @@
 import copy
 import traceback
 
+import wrapt
+
 from .entity import Entity
 from ..exceptions.exceptions import SegmentNotFoundException
 
@@ -15,6 +17,19 @@ class SubsegmentContextManager:
         self.subsegment_kwargs = subsegment_kwargs
         self.recorder = recorder
         self.subsegment = None
+
+    @wrapt.decorator
+    def __call__(self, wrapped, instance, args, kwargs):
+        func_name = self.name
+        if not func_name:
+            func_name = wrapped.__name__
+
+        return self.recorder.record_subsegment(
+            wrapped, instance, args, kwargs,
+            name=func_name,
+            namespace='local',
+            meta_processor=None,
+        )
 
     def __enter__(self):
         self.subsegment = self.recorder.begin_subsegment(

--- a/aws_xray_sdk/core/models/subsegment.py
+++ b/aws_xray_sdk/core/models/subsegment.py
@@ -1,7 +1,39 @@
 import copy
+import traceback
 
 from .entity import Entity
 from ..exceptions.exceptions import SegmentNotFoundException
+
+
+class SubsegmentContextManager:
+    """
+    Wrapper for segment and recorder to provide segment context manager.
+    """
+
+    def __init__(self, recorder, name=None, **subsegment_kwargs):
+        self.name = name
+        self.subsegment_kwargs = subsegment_kwargs
+        self.recorder = recorder
+        self.subsegment = None
+
+    def __enter__(self):
+        self.subsegment = self.recorder.begin_subsegment(
+            name=self.name, **self.subsegment_kwargs)
+        return self.subsegment
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        if self.subsegment is None:
+            return
+
+        if exc_type is not None:
+            self.subsegment.add_exception(
+                exc_val,
+                traceback.extract_tb(
+                    exc_tb,
+                    limit=self.recorder.max_trace_back,
+                )
+            )
+        self.recorder.end_subsegment()
 
 
 class Subsegment(Entity):

--- a/aws_xray_sdk/core/recorder.py
+++ b/aws_xray_sdk/core/recorder.py
@@ -8,8 +8,8 @@ import time
 import wrapt
 
 from aws_xray_sdk.version import VERSION
-from .models.segment import Segment
-from .models.subsegment import Subsegment
+from .models.segment import Segment, SegmentContextManager
+from .models.subsegment import Subsegment, SubsegmentContextManager
 from .models.default_dynamic_naming import DefaultDynamicNaming
 from .models.dummy_entities import DummySegment, DummySubsegment
 from .emitters.udp_emitter import UDPEmitter
@@ -177,6 +177,24 @@ class AWSXRayRecorder(object):
         if type(self.sampler).__name__ == 'DefaultSampler':
             self.sampler.load_settings(DaemonConfig(daemon_address),
                                        self.context, self._origin)
+
+    def in_segment(self, name=None, **segment_kwargs):
+        """
+        Return a segment context manger.
+
+        :param str name: the name of the segment
+        :param dict segment_kwargs: remaining arguments passed directly to `begin_segment`
+        """
+        return SegmentContextManager(self, name=name, **segment_kwargs)
+
+    def in_subsegment(self, name=None, **subsegment_kwargs):
+        """
+        Return a subsegment context manger.
+
+        :param str name: the name of the subsegment
+        :param dict segment_kwargs: remaining arguments passed directly to `begin_subsegment`
+        """
+        return SubsegmentContextManager(self, name=name, **subsegment_kwargs)
 
     def begin_segment(self, name=None, traceid=None,
                       parent_id=None, sampling=None):

--- a/aws_xray_sdk/core/recorder.py
+++ b/aws_xray_sdk/core/recorder.py
@@ -5,8 +5,6 @@ import os
 import platform
 import time
 
-import wrapt
-
 from aws_xray_sdk.version import VERSION
 from .models.segment import Segment, SegmentContextManager
 from .models.subsegment import Subsegment, SubsegmentContextManager
@@ -387,20 +385,7 @@ class AWSXRayRecorder(object):
         params str name: The name of the subsegment. If not specified
         the function name will be used.
         """
-        @wrapt.decorator
-        def wrapper(wrapped, instance, args, kwargs):
-            func_name = name
-            if not func_name:
-                func_name = wrapped.__name__
-
-            return self.record_subsegment(
-                wrapped, instance, args, kwargs,
-                name=func_name,
-                namespace='local',
-                meta_processor=None,
-            )
-
-        return wrapper
+        return self.in_subsegment(name=name)
 
     def record_subsegment(self, wrapped, instance, args, kwargs, name,
                           namespace, meta_processor):

--- a/tests/test_recorder.py
+++ b/tests/test_recorder.py
@@ -133,6 +133,10 @@ def test_in_segment_closing():
         with xray_recorder.in_subsegment('subsegment') as subsegment:
             assert subsegment.in_progress is True
 
+        with xray_recorder.capture('capture') as subsegment:
+            assert subsegment.in_progress is True
+            assert subsegment.name == 'capture'
+
     assert subsegment.in_progress is False
     assert segment.in_progress is False
     assert segment.annotations['key2'] == 'value2'


### PR DESCRIPTION
*Issue #, if available:* #77

*Description of changes:*

Changes in this PR adds support for use of `Segment` and `Subsegment` with context manager protocol and add support for `AWSXRayRecorder.capture` to be used as a context manager (for subsegment) as well.

With `AWSXRayRecorder.capture` as context manager following code:

```python
subsegment = xray_recorder.begin_subsegment('name')
etype, eval, etraceback = None, None, None
try:
    do_work_here()
    subsegment.put_annotation('key', 'value')
    do_some_more_work()
except:
    etype, eval, etraceback = sys.exc_info()
finally:
    if etype is not None:
        subsegment.add_exception(
            eval,
            traceback.extract_tb(etraceback, limit=xray_recorder.max_trace_back))    
    xray_recorder.end_subsegment()
```

can be written as:

```python
with xray_recorder.capture('name') as subsegment:
    do_work_here()
    subsegment.put_annotation('key', 'value')
    do_some_more_work()
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
