### PR TITLE
Tell PyPI long description is markdown

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ setup(
     description='The AWS X-Ray SDK for Python (the SDK) enables Python developers to record'
                 ' and emit information from within their applications to the AWS X-Ray service.',
     long_description=long_description,
+    long_description_content_type='text/markdown',
 
     url='https://github.com/aws/aws-xray-sdk-python',
 


### PR DESCRIPTION
This will make it render properly there, as per this SO post: https://stackoverflow.com/a/26737258

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
