### PR TITLE
Remove the dependency on requests

### DIFF
--- a/aws_xray_sdk/core/plugins/ec2_plugin.py
+++ b/aws_xray_sdk/core/plugins/ec2_plugin.py
@@ -1,5 +1,7 @@
 import logging
-import requests
+from future.standard_library import install_aliases
+install_aliases()
+from urllib.request import urlopen
 
 log = logging.getLogger(__name__)
 
@@ -18,11 +20,12 @@ def initialize():
     try:
         runtime_context = {}
 
-        r = requests.get('http://169.254.169.254/latest/meta-data/instance-id', timeout=1)
-        runtime_context['instance_id'] = r.text
+        r = urlopen('http://169.254.169.254/latest/meta-data/instance-id', timeout=1)
+        runtime_context['instance_id'] = r.read().decode('utf-8')
 
-        r = requests.get('http://169.254.169.254/latest/meta-data/placement/availability-zone', timeout=1)
-        runtime_context['availability_zone'] = r.text
+        r = urlopen('http://169.254.169.254/latest/meta-data/placement/availability-zone',
+                    timeout=1)
+        runtime_context['availability_zone'] = r.read().decode('utf-8')
 
     except Exception:
         runtime_context = None

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,6 @@ setup(
         'jsonpickle',
         'enum34;python_version<"3.4"',
         'wrapt',
-        'requests',
         'future',
         'botocore>=1.11.3',
     ],


### PR DESCRIPTION
This removes the use of `requests` from the core functionality, which
results in `requests` being only used as extension, therefore not being
necessary as dependency anymore.

The motivation for this change is to get rid of all the dependencies of
`requests`, whose size sums up quite a bit, when not requiring to patch
`requests`. It follows the removal of `requests` from `botocore`, which
was done as part of [v1.11.0](https://botocore.amazonaws.com/v1/documentation/api/latest/index.html#upgrading-to-1-11-0).

By submitting this pull request, I confirm that my contribution is made
under the terms of the Apache 2.0 license.
