### PR TITLE
Add ability to enable/disable the SDK (#26)

### DIFF
--- a/aws_xray_sdk/__init__.py
+++ b/aws_xray_sdk/__init__.py
@@ -1,0 +1,3 @@
+from .sdk_config import SDKConfig
+
+global_sdk_config = SDKConfig()

--- a/aws_xray_sdk/core/lambda_launcher.py
+++ b/aws_xray_sdk/core/lambda_launcher.py
@@ -2,7 +2,7 @@ import os
 import logging
 import threading
 
-import aws_xray_sdk
+from aws_xray_sdk import global_sdk_config
 from .models.facade_segment import FacadeSegment
 from .models.trace_header import TraceHeader
 from .context import Context
@@ -94,7 +94,7 @@ class LambdaContext(Context):
         """
         header_str = os.getenv(LAMBDA_TRACE_HEADER_KEY)
         trace_header = TraceHeader.from_header_str(header_str)
-        if not aws_xray_sdk.global_sdk_config.sdk_enabled():
+        if not global_sdk_config.sdk_enabled():
             trace_header._sampled = False
 
         segment = getattr(self._local, 'segment', None)
@@ -128,7 +128,7 @@ class LambdaContext(Context):
         set by AWS Lambda and initialize storage for subsegments.
         """
         sampled = None
-        if not aws_xray_sdk.global_sdk_config.sdk_enabled():
+        if not global_sdk_config.sdk_enabled():
             # Force subsequent subsegments to be disabled and turned into DummySegments.
             sampled = False
         elif trace_header.sampled == 0:

--- a/aws_xray_sdk/core/lambda_launcher.py
+++ b/aws_xray_sdk/core/lambda_launcher.py
@@ -2,10 +2,9 @@ import os
 import logging
 import threading
 
-from aws_xray_sdk.sdk_config import SDKConfig
+import aws_xray_sdk
 from .models.facade_segment import FacadeSegment
 from .models.trace_header import TraceHeader
-from .models.dummy_entities import DummySubsegment
 from .context import Context
 
 log = logging.getLogger(__name__)
@@ -72,13 +71,9 @@ class LambdaContext(Context):
         current_entity = self.get_trace_entity()
 
         if not self._is_subsegment(current_entity) and current_entity.initializing:
-            log.warning("Subsegment %s discarded due to Lambda worker still initializing" % subsegment.name)
+            if sdk_config_module.sdk_enabled():
+                log.warning("Subsegment %s discarded due to Lambda worker still initializing" % subsegment.name)
             return
-
-        enabled = SDKConfig.sdk_enabled()
-        if not enabled:
-            # For lambda, if the SDK is not enabled, we force the subsegment to be a dummy segment.
-            subsegment = DummySubsegment(current_entity)
 
         current_entity.add_subsegment(subsegment)
         self._local.entities.append(subsegment)
@@ -99,6 +94,9 @@ class LambdaContext(Context):
         """
         header_str = os.getenv(LAMBDA_TRACE_HEADER_KEY)
         trace_header = TraceHeader.from_header_str(header_str)
+        if not aws_xray_sdk.global_sdk_config.sdk_enabled():
+            trace_header._sampled = False
+
         segment = getattr(self._local, 'segment', None)
 
         if segment:
@@ -130,7 +128,10 @@ class LambdaContext(Context):
         set by AWS Lambda and initialize storage for subsegments.
         """
         sampled = None
-        if trace_header.sampled == 0:
+        if not aws_xray_sdk.global_sdk_config.sdk_enabled():
+            # Force subsequent subsegments to be disabled and turned into DummySegments.
+            sampled = False
+        elif trace_header.sampled == 0:
             sampled = False
         elif trace_header.sampled == 1:
             sampled = True

--- a/aws_xray_sdk/core/patcher.py
+++ b/aws_xray_sdk/core/patcher.py
@@ -7,6 +7,7 @@ import re
 import sys
 import wrapt
 
+from aws_xray_sdk.sdk_config import SDKConfig
 from .utils.compat import PY2, is_classmethod, is_instance_method
 
 log = logging.getLogger(__name__)
@@ -60,6 +61,9 @@ def _is_valid_import(module):
 
 
 def patch(modules_to_patch, raise_errors=True, ignore_module_patterns=None):
+    enabled = SDKConfig.sdk_enabled()
+    if not enabled:
+        return  # Disable module patching if the SDK is disabled.
     modules = set()
     for module_to_patch in modules_to_patch:
         # boto3 depends on botocore and patching botocore is sufficient

--- a/aws_xray_sdk/core/patcher.py
+++ b/aws_xray_sdk/core/patcher.py
@@ -7,7 +7,7 @@ import re
 import sys
 import wrapt
 
-from aws_xray_sdk.sdk_config import SDKConfig
+import aws_xray_sdk
 from .utils.compat import PY2, is_classmethod, is_instance_method
 
 log = logging.getLogger(__name__)
@@ -61,7 +61,7 @@ def _is_valid_import(module):
 
 
 def patch(modules_to_patch, raise_errors=True, ignore_module_patterns=None):
-    enabled = SDKConfig.sdk_enabled()
+    enabled = aws_xray_sdk.global_sdk_config.sdk_enabled()
     if not enabled:
         return  # Disable module patching if the SDK is disabled.
     modules = set()

--- a/aws_xray_sdk/core/patcher.py
+++ b/aws_xray_sdk/core/patcher.py
@@ -7,7 +7,7 @@ import re
 import sys
 import wrapt
 
-import aws_xray_sdk
+from aws_xray_sdk import global_sdk_config
 from .utils.compat import PY2, is_classmethod, is_instance_method
 
 log = logging.getLogger(__name__)
@@ -61,8 +61,9 @@ def _is_valid_import(module):
 
 
 def patch(modules_to_patch, raise_errors=True, ignore_module_patterns=None):
-    enabled = aws_xray_sdk.global_sdk_config.sdk_enabled()
+    enabled = global_sdk_config.sdk_enabled()
     if not enabled:
+        log.debug("Skipped patching modules %s because the SDK is currently disabled." % ', '.join(modules_to_patch))
         return  # Disable module patching if the SDK is disabled.
     modules = set()
     for module_to_patch in modules_to_patch:

--- a/aws_xray_sdk/core/recorder.py
+++ b/aws_xray_sdk/core/recorder.py
@@ -5,7 +5,7 @@ import os
 import platform
 import time
 
-import aws_xray_sdk
+from aws_xray_sdk import global_sdk_config
 from aws_xray_sdk.version import VERSION
 from .models.segment import Segment, SegmentContextManager
 from .models.subsegment import Subsegment, SubsegmentContextManager
@@ -25,7 +25,6 @@ from .utils import stacktrace
 
 log = logging.getLogger(__name__)
 
-XRAY_ENABLED_KEY = 'AWS_XRAY_ENABLED'
 TRACING_NAME_KEY = 'AWS_XRAY_TRACING_NAME'
 DAEMON_ADDR_KEY = 'AWS_XRAY_DAEMON_ADDRESS'
 CONTEXT_MISSING_KEY = 'AWS_XRAY_CONTEXT_MISSING'
@@ -224,7 +223,7 @@ class AWSXRayRecorder(object):
         # To disable the recorder, we set the sampling decision to always be false.
         # This way, when segments are generated, they become dummy segments and are ultimately never sent.
         # The call to self._sampler.should_trace() is never called either so the poller threads are never started.
-        if not aws_xray_sdk.global_sdk_config.sdk_enabled():
+        if not global_sdk_config.sdk_enabled():
             sampling = 0
 
         # we respect the input sampling decision
@@ -408,7 +407,7 @@ class AWSXRayRecorder(object):
         # In the case when the SDK is disabled, we ensure that a parent segment exists, because this is usually
         # handled by the middleware. We generate a dummy segment as the parent segment if one doesn't exist.
         # This is to allow potential segment method calls to not throw exceptions in the captured method.
-        if not aws_xray_sdk.global_sdk_config.sdk_enabled():
+        if not global_sdk_config.sdk_enabled():
             try:
                 self.current_segment()
             except SegmentNotFoundException:

--- a/aws_xray_sdk/core/sampling/sampler.py
+++ b/aws_xray_sdk/core/sampling/sampler.py
@@ -9,7 +9,7 @@ from .rule_poller import RulePoller
 from .target_poller import TargetPoller
 from .connector import ServiceConnector
 from .reservoir import ReservoirDecision
-import aws_xray_sdk
+from aws_xray_sdk import global_sdk_config
 
 log = logging.getLogger(__name__)
 
@@ -38,7 +38,7 @@ class DefaultSampler(object):
         Start rule poller and target poller once X-Ray daemon address
         and context manager is in place.
         """
-        if not aws_xray_sdk.global_sdk_config.sdk_enabled():
+        if not global_sdk_config.sdk_enabled():
             return
 
         with self._lock:
@@ -55,7 +55,7 @@ class DefaultSampler(object):
         All optional arguments are extracted from incoming requests by
         X-Ray middleware to perform path based sampling.
         """
-        if not aws_xray_sdk.global_sdk_config.sdk_enabled():
+        if not global_sdk_config.sdk_enabled():
             return False
 
         if not self._started:

--- a/aws_xray_sdk/core/sampling/sampler.py
+++ b/aws_xray_sdk/core/sampling/sampler.py
@@ -9,6 +9,7 @@ from .rule_poller import RulePoller
 from .target_poller import TargetPoller
 from .connector import ServiceConnector
 from .reservoir import ReservoirDecision
+import aws_xray_sdk
 
 log = logging.getLogger(__name__)
 
@@ -37,6 +38,9 @@ class DefaultSampler(object):
         Start rule poller and target poller once X-Ray daemon address
         and context manager is in place.
         """
+        if not aws_xray_sdk.global_sdk_config.sdk_enabled():
+            return
+
         with self._lock:
             if not self._started:
                 self._rule_poller.start()
@@ -51,6 +55,9 @@ class DefaultSampler(object):
         All optional arguments are extracted from incoming requests by
         X-Ray middleware to perform path based sampling.
         """
+        if not aws_xray_sdk.global_sdk_config.sdk_enabled():
+            return False
+
         if not self._started:
             self.start() # only front-end that actually uses the sampler spawns poller threads
 

--- a/aws_xray_sdk/sdk_config.py
+++ b/aws_xray_sdk/sdk_config.py
@@ -1,11 +1,7 @@
 import os
+import logging
 
-
-class InvalidParameterTypeException(Exception):
-    """
-    Exception thrown when an invalid parameter is passed into SDKConfig.set_sdk_enabled.
-    """
-    pass
+log = logging.getLogger(__name__)
 
 
 class SDKConfig(object):
@@ -59,6 +55,4 @@ class SDKConfig(object):
                 cls.__SDK_ENABLED = value
             else:
                 cls.__SDK_ENABLED = True
-                raise InvalidParameterTypeException(
-                    "Invalid parameter type passed into set_sdk_enabled(). Defaulting to True..."
-                )
+                log.warning("Invalid parameter type passed into set_sdk_enabled(). Defaulting to True...")

--- a/aws_xray_sdk/sdk_config.py
+++ b/aws_xray_sdk/sdk_config.py
@@ -1,0 +1,35 @@
+import os
+
+
+class SDKConfig(object):
+    """
+    Global Configuration Class that defines SDK-level configuration properties.
+    It is recommended to only use the recorder to set this configuration's enabled
+    flag to maintain thread safety.
+    """
+    XRAY_ENABLED_KEY = 'AWS_XRAY_ENABLED'
+    __SDK_ENABLED = str(os.getenv(XRAY_ENABLED_KEY, 'true')).lower() != 'false'
+
+    @staticmethod
+    def sdk_enabled():
+        """
+        Returns whether the SDK is enabled or not.
+        """
+        return SDKConfig.__SDK_ENABLED
+
+    @staticmethod
+    def set_sdk_enabled(value):
+        """
+        Modifies the enabled flag if the "AWS_XRAY_ENABLED" environment variable is not set,
+        otherwise, set the enabled flag to be equal to the environment variable. If the
+        env variable is an invalid string boolean, it will default to true.
+
+        :param bool value: Flag to set whether the SDK is enabled or disabled.
+
+        Environment variables AWS_XRAY_ENABLED overrides argument value.
+        """
+        # Environment Variables take precedence over hardcoded configurations.
+        if SDKConfig.XRAY_ENABLED_KEY in os.environ:
+            SDKConfig.__SDK_ENABLED = str(os.getenv(SDKConfig.XRAY_ENABLED_KEY, 'true')).lower() != 'false'
+        else:
+            SDKConfig.__SDK_ENABLED = value

--- a/aws_xray_sdk/sdk_config.py
+++ b/aws_xray_sdk/sdk_config.py
@@ -1,4 +1,12 @@
 import os
+import aws_xray_sdk.core
+
+
+class InvalidParameterTypeException(Exception):
+    """
+    Exception thrown when an invalid parameter is passed into SDKConfig.set_sdk_enabled.
+    """
+    pass
 
 
 class SDKConfig(object):
@@ -7,18 +15,18 @@ class SDKConfig(object):
     It is recommended to only use the recorder to set this configuration's enabled
     flag to maintain thread safety.
     """
-    XRAY_ENABLED_KEY = 'AWS_XRAY_ENABLED'
+    XRAY_ENABLED_KEY = 'AWS_XRAY_SDK_ENABLED'
     __SDK_ENABLED = str(os.getenv(XRAY_ENABLED_KEY, 'true')).lower() != 'false'
 
-    @staticmethod
-    def sdk_enabled():
+    @classmethod
+    def sdk_enabled(cls):
         """
         Returns whether the SDK is enabled or not.
         """
-        return SDKConfig.__SDK_ENABLED
+        return cls.__SDK_ENABLED
 
-    @staticmethod
-    def set_sdk_enabled(value):
+    @classmethod
+    def set_sdk_enabled(cls, value):
         """
         Modifies the enabled flag if the "AWS_XRAY_ENABLED" environment variable is not set,
         otherwise, set the enabled flag to be equal to the environment variable. If the
@@ -29,7 +37,16 @@ class SDKConfig(object):
         Environment variables AWS_XRAY_ENABLED overrides argument value.
         """
         # Environment Variables take precedence over hardcoded configurations.
-        if SDKConfig.XRAY_ENABLED_KEY in os.environ:
-            SDKConfig.__SDK_ENABLED = str(os.getenv(SDKConfig.XRAY_ENABLED_KEY, 'true')).lower() != 'false'
+        if cls.XRAY_ENABLED_KEY in os.environ:
+            cls.__SDK_ENABLED = str(os.getenv(cls.XRAY_ENABLED_KEY, 'true')).lower() != 'false'
         else:
-            SDKConfig.__SDK_ENABLED = value
+            if type(value) == bool:
+                cls.__SDK_ENABLED = value
+            else:
+                cls.__SDK_ENABLED = True
+                raise InvalidParameterTypeException(
+                    "Invalid parameter type passed into set_sdk_enabled(). Defaulting to True..."
+                )
+
+        # Modify all key paths.
+        aws_xray_sdk.core.xray_recorder.configure(enabled=cls.__SDK_ENABLED)

--- a/aws_xray_sdk/sdk_config.py
+++ b/aws_xray_sdk/sdk_config.py
@@ -1,5 +1,4 @@
 import os
-import aws_xray_sdk.core
 
 
 class InvalidParameterTypeException(Exception):
@@ -12,8 +11,24 @@ class InvalidParameterTypeException(Exception):
 class SDKConfig(object):
     """
     Global Configuration Class that defines SDK-level configuration properties.
-    It is recommended to only use the recorder to set this configuration's enabled
-    flag to maintain thread safety.
+
+    Enabling/Disabling the SDK:
+        By default, the SDK is enabled unless if an environment variable AWS_XRAY_SDK_ENABLED
+            is set. If it is set, it needs to be a valid string boolean, otherwise, it will default
+            to true. If the environment variable is set, all calls to set_sdk_enabled() will
+            prioritize the value of the environment variable.
+        Disabling the SDK affects the recorder, patcher, and middlewares in the following ways:
+        For the recorder, disabling automatically generates DummySegments for subsequent segments
+            and DummySubsegments for subsegments created and thus not send any traces to the daemon.
+        For the patcher, module patching will automatically be disabled. The SDK must be disabled
+            before calling patcher.patch() method in order for this to function properly.
+        For the middleware, no modification is made on them, but since the recorder automatically
+            generates DummySegments for all subsequent calls, they will not generate segments/subsegments
+            to be sent.
+
+    Environment variables:
+        "AWS_XRAY_SDK_ENABLED" - If set to 'false' disables the SDK and causes the explained above
+            to occur.
     """
     XRAY_ENABLED_KEY = 'AWS_XRAY_SDK_ENABLED'
     __SDK_ENABLED = str(os.getenv(XRAY_ENABLED_KEY, 'true')).lower() != 'false'
@@ -28,13 +43,13 @@ class SDKConfig(object):
     @classmethod
     def set_sdk_enabled(cls, value):
         """
-        Modifies the enabled flag if the "AWS_XRAY_ENABLED" environment variable is not set,
+        Modifies the enabled flag if the "AWS_XRAY_SDK_ENABLED" environment variable is not set,
         otherwise, set the enabled flag to be equal to the environment variable. If the
         env variable is an invalid string boolean, it will default to true.
 
         :param bool value: Flag to set whether the SDK is enabled or disabled.
 
-        Environment variables AWS_XRAY_ENABLED overrides argument value.
+        Environment variables AWS_XRAY_SDK_ENABLED overrides argument value.
         """
         # Environment Variables take precedence over hardcoded configurations.
         if cls.XRAY_ENABLED_KEY in os.environ:
@@ -47,6 +62,3 @@ class SDKConfig(object):
                 raise InvalidParameterTypeException(
                     "Invalid parameter type passed into set_sdk_enabled(). Defaulting to True..."
                 )
-
-        # Modify all key paths.
-        aws_xray_sdk.core.xray_recorder.configure(enabled=cls.__SDK_ENABLED)

--- a/tests/ext/aiohttp/test_middleware.py
+++ b/tests/ext/aiohttp/test_middleware.py
@@ -4,7 +4,7 @@ Tests the middleware for aiohttp server
 Expects pytest-aiohttp
 """
 import asyncio
-import aws_xray_sdk
+from aws_xray_sdk import global_sdk_config
 from unittest.mock import patch
 
 from aiohttp import web
@@ -110,7 +110,7 @@ def recorder(loop):
 
     xray_recorder.clear_trace_entities()
     yield xray_recorder
-    aws_xray_sdk.global_sdk_config.set_sdk_enabled(True)
+    global_sdk_config.set_sdk_enabled(True)
     xray_recorder.clear_trace_entities()
     patcher.stop()
 
@@ -295,7 +295,7 @@ async def test_disabled_sdk(test_client, loop, recorder):
     :param loop: Eventloop fixture
     :param recorder: X-Ray recorder fixture
     """
-    aws_xray_sdk.global_sdk_config.set_sdk_enabled(False)
+    global_sdk_config.set_sdk_enabled(False)
     client = await test_client(ServerTest.app(loop=loop))
 
     resp = await client.get('/')

--- a/tests/ext/aiohttp/test_middleware.py
+++ b/tests/ext/aiohttp/test_middleware.py
@@ -4,7 +4,7 @@ Tests the middleware for aiohttp server
 Expects pytest-aiohttp
 """
 import asyncio
-import aws_xray_sdk.sdk_config_module
+import aws_xray_sdk
 from unittest.mock import patch
 
 from aiohttp import web
@@ -109,9 +109,8 @@ def recorder(loop):
     patcher.start()
 
     xray_recorder.clear_trace_entities()
-    sdk_enabled_state = aws_xray_sdk.global_sdk_config.sdk_enabled()
     yield xray_recorder
-    aws_xray_sdk.global_sdk_config.set_sdk_enabled(sdk_enabled_state)
+    aws_xray_sdk.global_sdk_config.set_sdk_enabled(True)
     xray_recorder.clear_trace_entities()
     patcher.stop()
 

--- a/tests/ext/aiohttp/test_middleware.py
+++ b/tests/ext/aiohttp/test_middleware.py
@@ -283,3 +283,21 @@ async def test_concurrent(test_client, loop, recorder):
     # Ensure all ID's are different
     ids = [item.id for item in recorder.emitter.local]
     assert len(ids) == len(set(ids))
+
+
+async def test_disabled_sdk(test_client, loop, recorder):
+    """
+    Test a normal response when the SDK is disabled.
+
+    :param test_client: AioHttp test client fixture
+    :param loop: Eventloop fixture
+    :param recorder: X-Ray recorder fixture
+    """
+    recorder.configure(enabled=False)
+    client = await test_client(ServerTest.app(loop=loop))
+
+    resp = await client.get('/')
+    assert resp.status == 200
+
+    segment = recorder.emitter.pop()
+    assert not segment

--- a/tests/ext/aiohttp/test_middleware.py
+++ b/tests/ext/aiohttp/test_middleware.py
@@ -4,6 +4,7 @@ Tests the middleware for aiohttp server
 Expects pytest-aiohttp
 """
 import asyncio
+import aws_xray_sdk.sdk_config_module
 from unittest.mock import patch
 
 from aiohttp import web
@@ -108,7 +109,9 @@ def recorder(loop):
     patcher.start()
 
     xray_recorder.clear_trace_entities()
+    sdk_enabled_state = aws_xray_sdk.global_sdk_config.sdk_enabled()
     yield xray_recorder
+    aws_xray_sdk.global_sdk_config.set_sdk_enabled(sdk_enabled_state)
     xray_recorder.clear_trace_entities()
     patcher.stop()
 
@@ -293,7 +296,7 @@ async def test_disabled_sdk(test_client, loop, recorder):
     :param loop: Eventloop fixture
     :param recorder: X-Ray recorder fixture
     """
-    recorder.configure(enabled=False)
+    aws_xray_sdk.global_sdk_config.set_sdk_enabled(False)
     client = await test_client(ServerTest.app(loop=loop))
 
     resp = await client.get('/')

--- a/tests/ext/django/test_middleware.py
+++ b/tests/ext/django/test_middleware.py
@@ -102,3 +102,10 @@ class XRayTestCase(TestCase):
 
         assert 'Sampled=1' in trace_header
         assert segment.trace_id in trace_header
+
+    def test_disabled_sdk(self):
+        xray_recorder.configure(enabled=False)
+        url = reverse('200ok')
+        self.client.get(url)
+        segment = xray_recorder.emitter.pop()
+        assert not segment

--- a/tests/ext/django/test_middleware.py
+++ b/tests/ext/django/test_middleware.py
@@ -1,5 +1,5 @@
 import django
-import aws_xray_sdk
+from aws_xray_sdk import global_sdk_config
 from django.core.urlresolvers import reverse
 from django.test import TestCase
 
@@ -15,7 +15,7 @@ class XRayTestCase(TestCase):
         xray_recorder.configure(context=Context(),
                                 context_missing='LOG_ERROR')
         xray_recorder.clear_trace_entities()
-        aws_xray_sdk.global_sdk_config.set_sdk_enabled(True)
+        global_sdk_config.set_sdk_enabled(True)
 
     def tearDown(self):
         xray_recorder.clear_trace_entities()
@@ -106,7 +106,7 @@ class XRayTestCase(TestCase):
         assert segment.trace_id in trace_header
 
     def test_disabled_sdk(self):
-        aws_xray_sdk.global_sdk_config.set_sdk_enabled(False)
+        global_sdk_config.set_sdk_enabled(False)
         url = reverse('200ok')
         self.client.get(url)
         segment = xray_recorder.emitter.pop()

--- a/tests/ext/django/test_middleware.py
+++ b/tests/ext/django/test_middleware.py
@@ -1,4 +1,5 @@
 import django
+import aws_xray_sdk
 from django.core.urlresolvers import reverse
 from django.test import TestCase
 
@@ -14,6 +15,7 @@ class XRayTestCase(TestCase):
         xray_recorder.configure(context=Context(),
                                 context_missing='LOG_ERROR')
         xray_recorder.clear_trace_entities()
+        aws_xray_sdk.global_sdk_config.set_sdk_enabled(True)
 
     def tearDown(self):
         xray_recorder.clear_trace_entities()
@@ -104,7 +106,7 @@ class XRayTestCase(TestCase):
         assert segment.trace_id in trace_header
 
     def test_disabled_sdk(self):
-        xray_recorder.configure(enabled=False)
+        aws_xray_sdk.global_sdk_config.set_sdk_enabled(False)
         url = reverse('200ok')
         self.client.get(url)
         segment = xray_recorder.emitter.pop()

--- a/tests/ext/flask/test_flask.py
+++ b/tests/ext/flask/test_flask.py
@@ -143,3 +143,11 @@ def test_sampled_response_header():
     resp_header = resp.headers[http.XRAY_HEADER]
     assert segment.trace_id in resp_header
     assert 'Sampled=1' in resp_header
+
+
+def test_disabled_sdk():
+    recorder.configure(enabled=False)
+    path = '/ok'
+    app.get(path)
+    segment = recorder.emitter.pop()
+    assert not segment

--- a/tests/ext/flask/test_flask.py
+++ b/tests/ext/flask/test_flask.py
@@ -1,7 +1,7 @@
 import pytest
 from flask import Flask, render_template_string
 
-import aws_xray_sdk
+from aws_xray_sdk import global_sdk_config
 from aws_xray_sdk.ext.flask.middleware import XRayMiddleware
 from aws_xray_sdk.core.context import Context
 from aws_xray_sdk.core.models import http
@@ -52,7 +52,7 @@ def cleanup():
     recorder.clear_trace_entities()
     yield
     recorder.clear_trace_entities()
-    aws_xray_sdk.global_sdk_config.set_sdk_enabled(True)
+    global_sdk_config.set_sdk_enabled(True)
 
 
 def test_ok():
@@ -148,7 +148,7 @@ def test_sampled_response_header():
 
 
 def test_disabled_sdk():
-    aws_xray_sdk.global_sdk_config.set_sdk_enabled(False)
+    global_sdk_config.set_sdk_enabled(False)
     path = '/ok'
     app.get(path)
     segment = recorder.emitter.pop()

--- a/tests/ext/flask/test_flask.py
+++ b/tests/ext/flask/test_flask.py
@@ -1,6 +1,7 @@
 import pytest
 from flask import Flask, render_template_string
 
+import aws_xray_sdk
 from aws_xray_sdk.ext.flask.middleware import XRayMiddleware
 from aws_xray_sdk.core.context import Context
 from aws_xray_sdk.core.models import http
@@ -51,6 +52,7 @@ def cleanup():
     recorder.clear_trace_entities()
     yield
     recorder.clear_trace_entities()
+    aws_xray_sdk.global_sdk_config.set_sdk_enabled(True)
 
 
 def test_ok():
@@ -146,7 +148,7 @@ def test_sampled_response_header():
 
 
 def test_disabled_sdk():
-    recorder.configure(enabled=False)
+    aws_xray_sdk.global_sdk_config.set_sdk_enabled(False)
     path = '/ok'
     app.get(path)
     segment = recorder.emitter.pop()

--- a/tests/test_lambda_context.py
+++ b/tests/test_lambda_context.py
@@ -1,9 +1,9 @@
 import os
 
 import aws_xray_sdk
+import pytest
 from aws_xray_sdk.core import lambda_launcher
 from aws_xray_sdk.core.models.subsegment import Subsegment
-from aws_xray_sdk.core.models.dummy_entities import DummySubsegment
 
 
 TRACE_ID = '1-5759e988-bd862e3fe1be46a994272793'
@@ -12,7 +12,12 @@ HEADER_VAR = "Root=%s;Parent=%s;Sampled=1" % (TRACE_ID, PARENT_ID)
 
 os.environ[lambda_launcher.LAMBDA_TRACE_HEADER_KEY] = HEADER_VAR
 context = lambda_launcher.LambdaContext()
-aws_xray_sdk.global_sdk_config.set_sdk_enabled(True)
+
+
+@pytest.fixture(autouse=True)
+def setup():
+    yield
+    aws_xray_sdk.global_sdk_config.set_sdk_enabled(True)
 
 
 def test_facade_segment_generation():

--- a/tests/test_lambda_context.py
+++ b/tests/test_lambda_context.py
@@ -1,6 +1,6 @@
 import os
 
-import aws_xray_sdk
+from aws_xray_sdk import global_sdk_config
 import pytest
 from aws_xray_sdk.core import lambda_launcher
 from aws_xray_sdk.core.models.subsegment import Subsegment
@@ -17,7 +17,7 @@ context = lambda_launcher.LambdaContext()
 @pytest.fixture(autouse=True)
 def setup():
     yield
-    aws_xray_sdk.global_sdk_config.set_sdk_enabled(True)
+    global_sdk_config.set_sdk_enabled(True)
 
 
 def test_facade_segment_generation():
@@ -57,6 +57,6 @@ def test_disable():
     assert segment.sampled
 
     context.clear_trace_entities()
-    aws_xray_sdk.global_sdk_config.set_sdk_enabled(False)
+    global_sdk_config.set_sdk_enabled(False)
     segment = context.get_trace_entity()
     assert not segment.sampled

--- a/tests/test_lambda_context.py
+++ b/tests/test_lambda_context.py
@@ -1,7 +1,9 @@
 import os
 
+from aws_xray_sdk.sdk_config import SDKConfig
 from aws_xray_sdk.core import lambda_launcher
 from aws_xray_sdk.core.models.subsegment import Subsegment
+from aws_xray_sdk.core.models.dummy_entities import DummySubsegment
 
 
 TRACE_ID = '1-5759e988-bd862e3fe1be46a994272793'
@@ -41,3 +43,11 @@ def test_put_subsegment():
 
     context.end_subsegment()
     assert context.get_trace_entity().id == segment.id
+
+
+def test_disable():
+    SDKConfig.set_sdk_enabled(False)
+    segment = context.get_trace_entity()
+    subsegment = Subsegment('name', 'local', segment)
+    context.put_subsegment(subsegment)
+    assert type(context.get_trace_entity()) is DummySubsegment

--- a/tests/test_patcher.py
+++ b/tests/test_patcher.py
@@ -13,7 +13,7 @@ except ImportError:
         # Python versions < 3 have reload built-in
         pass
 
-import aws_xray_sdk
+from aws_xray_sdk import global_sdk_config
 from aws_xray_sdk.core import patcher, xray_recorder
 from aws_xray_sdk.core.context import Context
 
@@ -41,7 +41,7 @@ def construct_ctx():
     yield
     xray_recorder.end_segment()
     xray_recorder.clear_trace_entities()
-    aws_xray_sdk.global_sdk_config.set_sdk_enabled(True)
+    global_sdk_config.set_sdk_enabled(True)
 
     # Reload wrapt.importer references to modules to start off clean
     reload(wrapt)
@@ -177,7 +177,7 @@ def test_external_submodules_ignores_module():
 
 
 def test_disable_sdk_disables_patching():
-    aws_xray_sdk.global_sdk_config.set_sdk_enabled(False)
+    global_sdk_config.set_sdk_enabled(False)
     patcher.patch(['tests.mock_module'])
     imported_modules = [module for module in TEST_MODULES if module in sys.modules]
     assert not imported_modules

--- a/tests/test_patcher.py
+++ b/tests/test_patcher.py
@@ -35,7 +35,6 @@ def construct_ctx():
     """
     pre_run_modules = set(module for module in sys.modules.keys())
 
-    aws_xray_sdk.global_sdk_config.set_sdk_enabled(True)
     xray_recorder.configure(service='test', sampling=False, context=Context())
     xray_recorder.clear_trace_entities()
     xray_recorder.begin_segment('name')

--- a/tests/test_patcher.py
+++ b/tests/test_patcher.py
@@ -13,6 +13,7 @@ except ImportError:
         # Python versions < 3 have reload built-in
         pass
 
+from aws_xray_sdk.sdk_config import SDKConfig
 from aws_xray_sdk.core import patcher, xray_recorder
 from aws_xray_sdk.core.context import Context
 
@@ -172,3 +173,11 @@ def test_external_submodules_ignores_module():
     assert xray_recorder.current_segment().subsegments[0].name == 'mock_init'
     assert xray_recorder.current_segment().subsegments[1].name == 'mock_func'
     assert xray_recorder.current_segment().subsegments[2].name == 'mock_no_doublepatch'  # It is patched with decorator
+
+
+def test_disable_sdk_disables_patching():
+    SDKConfig.set_sdk_enabled(False)
+    patcher.patch(['tests.mock_module'])
+    imported_modules = [module for module in TEST_MODULES if module in sys.modules]
+    assert not imported_modules
+    assert len(xray_recorder.current_segment().subsegments) == 0

--- a/tests/test_recorder.py
+++ b/tests/test_recorder.py
@@ -5,13 +5,13 @@ import pytest
 from aws_xray_sdk.version import VERSION
 from .util import get_new_stubbed_recorder
 
-import aws_xray_sdk
+from aws_xray_sdk import global_sdk_config
 from aws_xray_sdk.core.models.segment import Segment
 from aws_xray_sdk.core.models.subsegment import Subsegment
 from aws_xray_sdk.core.models.dummy_entities import DummySegment, DummySubsegment
 
 xray_recorder = get_new_stubbed_recorder()
-XRAY_ENABLED_KEY = aws_xray_sdk.global_sdk_config.XRAY_ENABLED_KEY
+XRAY_ENABLED_KEY = global_sdk_config.XRAY_ENABLED_KEY
 
 
 @pytest.fixture(autouse=True)
@@ -23,7 +23,7 @@ def construct_ctx():
     xray_recorder.clear_trace_entities()
     yield
     xray_recorder.clear_trace_entities()
-    aws_xray_sdk.global_sdk_config.set_sdk_enabled(True)
+    global_sdk_config.set_sdk_enabled(True)
 
 
 def test_default_runtime_context():
@@ -176,7 +176,7 @@ def test_in_segment_exception():
 
 
 def test_default_enabled():
-    assert aws_xray_sdk.global_sdk_config.sdk_enabled()
+    assert global_sdk_config.sdk_enabled()
     segment = xray_recorder.begin_segment('name')
     subsegment = xray_recorder.begin_subsegment('name')
     assert type(xray_recorder.current_segment()) is Segment
@@ -184,7 +184,7 @@ def test_default_enabled():
 
 
 def test_disable_is_dummy():
-    aws_xray_sdk.global_sdk_config.set_sdk_enabled(False)
+    global_sdk_config.set_sdk_enabled(False)
     segment = xray_recorder.begin_segment('name')
     subsegment = xray_recorder.begin_subsegment('name')
     assert type(xray_recorder.current_segment()) is DummySegment

--- a/tests/test_recorder.py
+++ b/tests/test_recorder.py
@@ -5,14 +5,13 @@ import pytest
 from aws_xray_sdk.version import VERSION
 from .util import get_new_stubbed_recorder
 
-import os
-from aws_xray_sdk.sdk_config import SDKConfig
+import aws_xray_sdk
 from aws_xray_sdk.core.models.segment import Segment
 from aws_xray_sdk.core.models.subsegment import Subsegment
 from aws_xray_sdk.core.models.dummy_entities import DummySegment, DummySubsegment
 
 xray_recorder = get_new_stubbed_recorder()
-XRAY_ENABLED_KEY = SDKConfig.XRAY_ENABLED_KEY
+XRAY_ENABLED_KEY = aws_xray_sdk.global_sdk_config.XRAY_ENABLED_KEY
 
 
 @pytest.fixture(autouse=True)
@@ -188,30 +187,3 @@ def test_disable_is_dummy():
     subsegment = xray_recorder.begin_subsegment('name')
     assert type(xray_recorder.current_segment()) is DummySegment
     assert type(xray_recorder.current_subsegment()) is DummySubsegment
-
-
-def test_disable_env_precedence():
-    os.environ[XRAY_ENABLED_KEY] = "False"
-    xray_recorder.configure(enabled=True)
-    segment = xray_recorder.begin_segment('name')
-    subsegment = xray_recorder.begin_subsegment('name')
-    assert type(xray_recorder.current_segment()) is DummySegment
-    assert type(xray_recorder.current_subsegment()) is DummySubsegment
-
-
-def test_disable_env():
-    os.environ[XRAY_ENABLED_KEY] = "False"
-    xray_recorder.configure(enabled=False)
-    segment = xray_recorder.begin_segment('name')
-    subsegment = xray_recorder.begin_subsegment('name')
-    assert type(xray_recorder.current_segment()) is DummySegment
-    assert type(xray_recorder.current_subsegment()) is DummySubsegment
-
-
-def test_enable_env():
-    os.environ[XRAY_ENABLED_KEY] = "True"
-    xray_recorder.configure(enabled=True)
-    segment = xray_recorder.begin_segment('name')
-    subsegment = xray_recorder.begin_subsegment('name')
-    assert type(xray_recorder.current_segment()) is Segment
-    assert type(xray_recorder.current_subsegment()) is Subsegment

--- a/tests/test_recorder.py
+++ b/tests/test_recorder.py
@@ -23,6 +23,7 @@ def construct_ctx():
     xray_recorder.clear_trace_entities()
     yield
     xray_recorder.clear_trace_entities()
+    aws_xray_sdk.global_sdk_config.set_sdk_enabled(True)
 
 
 def test_default_runtime_context():
@@ -175,6 +176,7 @@ def test_in_segment_exception():
 
 
 def test_default_enabled():
+    assert aws_xray_sdk.global_sdk_config.sdk_enabled()
     segment = xray_recorder.begin_segment('name')
     subsegment = xray_recorder.begin_subsegment('name')
     assert type(xray_recorder.current_segment()) is Segment
@@ -182,7 +184,7 @@ def test_default_enabled():
 
 
 def test_disable_is_dummy():
-    xray_recorder.configure(enabled=False)
+    aws_xray_sdk.global_sdk_config.set_sdk_enabled(False)
     segment = xray_recorder.begin_segment('name')
     subsegment = xray_recorder.begin_subsegment('name')
     assert type(xray_recorder.current_segment()) is DummySegment

--- a/tests/test_recorder.py
+++ b/tests/test_recorder.py
@@ -11,7 +11,6 @@ from aws_xray_sdk.core.models.subsegment import Subsegment
 from aws_xray_sdk.core.models.dummy_entities import DummySegment, DummySubsegment
 
 xray_recorder = get_new_stubbed_recorder()
-XRAY_ENABLED_KEY = global_sdk_config.XRAY_ENABLED_KEY
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_sdk_config.py
+++ b/tests/test_sdk_config.py
@@ -1,9 +1,9 @@
-from aws_xray_sdk.sdk_config import SDKConfig
+import aws_xray_sdk
 import os
 import pytest
 
 
-XRAY_ENABLED_KEY = "AWS_XRAY_ENABLED"
+XRAY_ENABLED_KEY = "AWS_XRAY_SDK_ENABLED"
 
 
 @pytest.fixture(autouse=True)
@@ -19,58 +19,58 @@ def cleanup():
 
 
 def test_enable_key():
-    assert SDKConfig.XRAY_ENABLED_KEY == XRAY_ENABLED_KEY
+    assert aws_xray_sdk.global_sdk_config.XRAY_ENABLED_KEY == XRAY_ENABLED_KEY
 
 
 def test_default_enabled():
-    assert SDKConfig.sdk_enabled() is True
+    assert aws_xray_sdk.global_sdk_config.sdk_enabled() is True
 
 
 def test_env_var_precedence():
     os.environ[XRAY_ENABLED_KEY] = "true"
-    SDKConfig.set_sdk_enabled(False)
-    assert SDKConfig.sdk_enabled() is True
+    aws_xray_sdk.global_sdk_config.set_sdk_enabled(False)
+    assert aws_xray_sdk.global_sdk_config.sdk_enabled() is True
     os.environ[XRAY_ENABLED_KEY] = "false"
-    SDKConfig.set_sdk_enabled(False)
-    assert SDKConfig.sdk_enabled() is False
+    aws_xray_sdk.global_sdk_config.set_sdk_enabled(False)
+    assert aws_xray_sdk.global_sdk_config.sdk_enabled() is False
     os.environ[XRAY_ENABLED_KEY] = "false"
-    SDKConfig.set_sdk_enabled(True)
-    assert SDKConfig.sdk_enabled() is False
+    aws_xray_sdk.global_sdk_config.set_sdk_enabled(True)
+    assert aws_xray_sdk.global_sdk_config.sdk_enabled() is False
     os.environ[XRAY_ENABLED_KEY] = "true"
-    SDKConfig.set_sdk_enabled(True)
-    assert SDKConfig.sdk_enabled() is True
+    aws_xray_sdk.global_sdk_config.set_sdk_enabled(True)
+    assert aws_xray_sdk.global_sdk_config.sdk_enabled() is True
     os.environ[XRAY_ENABLED_KEY] = "true"
-    SDKConfig.set_sdk_enabled(None)
-    assert SDKConfig.sdk_enabled() is True
+    aws_xray_sdk.global_sdk_config.set_sdk_enabled(None)
+    assert aws_xray_sdk.global_sdk_config.sdk_enabled() is True
 
 
 def test_env_enable_case():
     os.environ[XRAY_ENABLED_KEY] = "TrUE"
-    SDKConfig.set_sdk_enabled(True)  # Env Variable takes precedence. This is called to activate the internal check
-    assert SDKConfig.sdk_enabled() is True
+    aws_xray_sdk.global_sdk_config.set_sdk_enabled(True)  # Env Variable takes precedence. This is called to activate the internal check
+    assert aws_xray_sdk.global_sdk_config.sdk_enabled() is True
 
     os.environ[XRAY_ENABLED_KEY] = "true"
-    SDKConfig.set_sdk_enabled(True)
-    assert SDKConfig.sdk_enabled() is True
+    aws_xray_sdk.global_sdk_config.set_sdk_enabled(True)
+    assert aws_xray_sdk.global_sdk_config.sdk_enabled() is True
 
     os.environ[XRAY_ENABLED_KEY] = "False"
-    SDKConfig.set_sdk_enabled(True)
-    assert SDKConfig.sdk_enabled() is False
+    aws_xray_sdk.global_sdk_config.set_sdk_enabled(True)
+    assert aws_xray_sdk.global_sdk_config.sdk_enabled() is False
 
     os.environ[XRAY_ENABLED_KEY] = "falSE"
-    SDKConfig.set_sdk_enabled(True)
-    assert SDKConfig.sdk_enabled() is False
+    aws_xray_sdk.global_sdk_config.set_sdk_enabled(True)
+    assert aws_xray_sdk.global_sdk_config.sdk_enabled() is False
 
 
 def test_invalid_env_string():
     os.environ[XRAY_ENABLED_KEY] = "INVALID"
-    SDKConfig.set_sdk_enabled(True)  # Env Variable takes precedence. This is called to activate the internal check
-    assert SDKConfig.sdk_enabled() is True
+    aws_xray_sdk.global_sdk_config.set_sdk_enabled(True)  # Env Variable takes precedence. This is called to activate the internal check
+    assert aws_xray_sdk.global_sdk_config.sdk_enabled() is True
 
     os.environ[XRAY_ENABLED_KEY] = "1.0"
-    SDKConfig.set_sdk_enabled(True)
-    assert SDKConfig.sdk_enabled() is True
+    aws_xray_sdk.global_sdk_config.set_sdk_enabled(True)
+    assert aws_xray_sdk.global_sdk_config.sdk_enabled() is True
 
     os.environ[XRAY_ENABLED_KEY] = "1-.0"
-    SDKConfig.set_sdk_enabled(False)
-    assert SDKConfig.sdk_enabled() is True
+    aws_xray_sdk.global_sdk_config.set_sdk_enabled(False)
+    assert aws_xray_sdk.global_sdk_config.sdk_enabled() is True

--- a/tests/test_sdk_config.py
+++ b/tests/test_sdk_config.py
@@ -1,0 +1,76 @@
+from aws_xray_sdk.sdk_config import SDKConfig
+import os
+import pytest
+
+
+XRAY_ENABLED_KEY = "AWS_XRAY_ENABLED"
+
+
+@pytest.fixture(autouse=True)
+def cleanup():
+    """
+    Clean up Environmental Variable for enable before and after tests
+    """
+    if XRAY_ENABLED_KEY in os.environ:
+        del os.environ[XRAY_ENABLED_KEY]
+    yield
+    if XRAY_ENABLED_KEY in os.environ:
+        del os.environ[XRAY_ENABLED_KEY]
+
+
+def test_enable_key():
+    assert SDKConfig.XRAY_ENABLED_KEY == XRAY_ENABLED_KEY
+
+
+def test_default_enabled():
+    assert SDKConfig.sdk_enabled() is True
+
+
+def test_env_var_precedence():
+    os.environ[XRAY_ENABLED_KEY] = "true"
+    SDKConfig.set_sdk_enabled(False)
+    assert SDKConfig.sdk_enabled() is True
+    os.environ[XRAY_ENABLED_KEY] = "false"
+    SDKConfig.set_sdk_enabled(False)
+    assert SDKConfig.sdk_enabled() is False
+    os.environ[XRAY_ENABLED_KEY] = "false"
+    SDKConfig.set_sdk_enabled(True)
+    assert SDKConfig.sdk_enabled() is False
+    os.environ[XRAY_ENABLED_KEY] = "true"
+    SDKConfig.set_sdk_enabled(True)
+    assert SDKConfig.sdk_enabled() is True
+    os.environ[XRAY_ENABLED_KEY] = "true"
+    SDKConfig.set_sdk_enabled(None)
+    assert SDKConfig.sdk_enabled() is True
+
+
+def test_env_enable_case():
+    os.environ[XRAY_ENABLED_KEY] = "TrUE"
+    SDKConfig.set_sdk_enabled(True)  # Env Variable takes precedence. This is called to activate the internal check
+    assert SDKConfig.sdk_enabled() is True
+
+    os.environ[XRAY_ENABLED_KEY] = "true"
+    SDKConfig.set_sdk_enabled(True)
+    assert SDKConfig.sdk_enabled() is True
+
+    os.environ[XRAY_ENABLED_KEY] = "False"
+    SDKConfig.set_sdk_enabled(True)
+    assert SDKConfig.sdk_enabled() is False
+
+    os.environ[XRAY_ENABLED_KEY] = "falSE"
+    SDKConfig.set_sdk_enabled(True)
+    assert SDKConfig.sdk_enabled() is False
+
+
+def test_invalid_env_string():
+    os.environ[XRAY_ENABLED_KEY] = "INVALID"
+    SDKConfig.set_sdk_enabled(True)  # Env Variable takes precedence. This is called to activate the internal check
+    assert SDKConfig.sdk_enabled() is True
+
+    os.environ[XRAY_ENABLED_KEY] = "1.0"
+    SDKConfig.set_sdk_enabled(True)
+    assert SDKConfig.sdk_enabled() is True
+
+    os.environ[XRAY_ENABLED_KEY] = "1-.0"
+    SDKConfig.set_sdk_enabled(False)
+    assert SDKConfig.sdk_enabled() is True

--- a/tests/test_sdk_config.py
+++ b/tests/test_sdk_config.py
@@ -16,6 +16,7 @@ def cleanup():
     yield
     if XRAY_ENABLED_KEY in os.environ:
         del os.environ[XRAY_ENABLED_KEY]
+    aws_xray_sdk.global_sdk_config.set_sdk_enabled(True)
 
 
 def test_enable_key():
@@ -28,6 +29,7 @@ def test_default_enabled():
 
 def test_env_var_precedence():
     os.environ[XRAY_ENABLED_KEY] = "true"
+    # Env Variable takes precedence. This is called to activate the internal check
     aws_xray_sdk.global_sdk_config.set_sdk_enabled(False)
     assert aws_xray_sdk.global_sdk_config.sdk_enabled() is True
     os.environ[XRAY_ENABLED_KEY] = "false"
@@ -46,7 +48,8 @@ def test_env_var_precedence():
 
 def test_env_enable_case():
     os.environ[XRAY_ENABLED_KEY] = "TrUE"
-    aws_xray_sdk.global_sdk_config.set_sdk_enabled(True)  # Env Variable takes precedence. This is called to activate the internal check
+    # Env Variable takes precedence. This is called to activate the internal check
+    aws_xray_sdk.global_sdk_config.set_sdk_enabled(True)
     assert aws_xray_sdk.global_sdk_config.sdk_enabled() is True
 
     os.environ[XRAY_ENABLED_KEY] = "true"
@@ -64,7 +67,8 @@ def test_env_enable_case():
 
 def test_invalid_env_string():
     os.environ[XRAY_ENABLED_KEY] = "INVALID"
-    aws_xray_sdk.global_sdk_config.set_sdk_enabled(True)  # Env Variable takes precedence. This is called to activate the internal check
+    # Env Variable takes precedence. This is called to activate the internal check
+    aws_xray_sdk.global_sdk_config.set_sdk_enabled(True)
     assert aws_xray_sdk.global_sdk_config.sdk_enabled() is True
 
     os.environ[XRAY_ENABLED_KEY] = "1.0"

--- a/tests/test_sdk_config.py
+++ b/tests/test_sdk_config.py
@@ -1,4 +1,4 @@
-import aws_xray_sdk
+from aws_xray_sdk import global_sdk_config
 import os
 import pytest
 
@@ -16,65 +16,65 @@ def cleanup():
     yield
     if XRAY_ENABLED_KEY in os.environ:
         del os.environ[XRAY_ENABLED_KEY]
-    aws_xray_sdk.global_sdk_config.set_sdk_enabled(True)
+    global_sdk_config.set_sdk_enabled(True)
 
 
 def test_enable_key():
-    assert aws_xray_sdk.global_sdk_config.XRAY_ENABLED_KEY == XRAY_ENABLED_KEY
+    assert global_sdk_config.XRAY_ENABLED_KEY == XRAY_ENABLED_KEY
 
 
 def test_default_enabled():
-    assert aws_xray_sdk.global_sdk_config.sdk_enabled() is True
+    assert global_sdk_config.sdk_enabled() is True
 
 
 def test_env_var_precedence():
     os.environ[XRAY_ENABLED_KEY] = "true"
     # Env Variable takes precedence. This is called to activate the internal check
-    aws_xray_sdk.global_sdk_config.set_sdk_enabled(False)
-    assert aws_xray_sdk.global_sdk_config.sdk_enabled() is True
+    global_sdk_config.set_sdk_enabled(False)
+    assert global_sdk_config.sdk_enabled() is True
     os.environ[XRAY_ENABLED_KEY] = "false"
-    aws_xray_sdk.global_sdk_config.set_sdk_enabled(False)
-    assert aws_xray_sdk.global_sdk_config.sdk_enabled() is False
+    global_sdk_config.set_sdk_enabled(False)
+    assert global_sdk_config.sdk_enabled() is False
     os.environ[XRAY_ENABLED_KEY] = "false"
-    aws_xray_sdk.global_sdk_config.set_sdk_enabled(True)
-    assert aws_xray_sdk.global_sdk_config.sdk_enabled() is False
+    global_sdk_config.set_sdk_enabled(True)
+    assert global_sdk_config.sdk_enabled() is False
     os.environ[XRAY_ENABLED_KEY] = "true"
-    aws_xray_sdk.global_sdk_config.set_sdk_enabled(True)
-    assert aws_xray_sdk.global_sdk_config.sdk_enabled() is True
+    global_sdk_config.set_sdk_enabled(True)
+    assert global_sdk_config.sdk_enabled() is True
     os.environ[XRAY_ENABLED_KEY] = "true"
-    aws_xray_sdk.global_sdk_config.set_sdk_enabled(None)
-    assert aws_xray_sdk.global_sdk_config.sdk_enabled() is True
+    global_sdk_config.set_sdk_enabled(None)
+    assert global_sdk_config.sdk_enabled() is True
 
 
 def test_env_enable_case():
     os.environ[XRAY_ENABLED_KEY] = "TrUE"
     # Env Variable takes precedence. This is called to activate the internal check
-    aws_xray_sdk.global_sdk_config.set_sdk_enabled(True)
-    assert aws_xray_sdk.global_sdk_config.sdk_enabled() is True
+    global_sdk_config.set_sdk_enabled(True)
+    assert global_sdk_config.sdk_enabled() is True
 
     os.environ[XRAY_ENABLED_KEY] = "true"
-    aws_xray_sdk.global_sdk_config.set_sdk_enabled(True)
-    assert aws_xray_sdk.global_sdk_config.sdk_enabled() is True
+    global_sdk_config.set_sdk_enabled(True)
+    assert global_sdk_config.sdk_enabled() is True
 
     os.environ[XRAY_ENABLED_KEY] = "False"
-    aws_xray_sdk.global_sdk_config.set_sdk_enabled(True)
-    assert aws_xray_sdk.global_sdk_config.sdk_enabled() is False
+    global_sdk_config.set_sdk_enabled(True)
+    assert global_sdk_config.sdk_enabled() is False
 
     os.environ[XRAY_ENABLED_KEY] = "falSE"
-    aws_xray_sdk.global_sdk_config.set_sdk_enabled(True)
-    assert aws_xray_sdk.global_sdk_config.sdk_enabled() is False
+    global_sdk_config.set_sdk_enabled(True)
+    assert global_sdk_config.sdk_enabled() is False
 
 
 def test_invalid_env_string():
     os.environ[XRAY_ENABLED_KEY] = "INVALID"
     # Env Variable takes precedence. This is called to activate the internal check
-    aws_xray_sdk.global_sdk_config.set_sdk_enabled(True)
-    assert aws_xray_sdk.global_sdk_config.sdk_enabled() is True
+    global_sdk_config.set_sdk_enabled(True)
+    assert global_sdk_config.sdk_enabled() is True
 
     os.environ[XRAY_ENABLED_KEY] = "1.0"
-    aws_xray_sdk.global_sdk_config.set_sdk_enabled(True)
-    assert aws_xray_sdk.global_sdk_config.sdk_enabled() is True
+    global_sdk_config.set_sdk_enabled(True)
+    assert global_sdk_config.sdk_enabled() is True
 
     os.environ[XRAY_ENABLED_KEY] = "1-.0"
-    aws_xray_sdk.global_sdk_config.set_sdk_enabled(False)
-    assert aws_xray_sdk.global_sdk_config.sdk_enabled() is True
+    global_sdk_config.set_sdk_enabled(False)
+    assert global_sdk_config.sdk_enabled() is True


### PR DESCRIPTION
Added the ability to enable/disable the SDK upon configuration. This prevents application unit tests that originally relied on segments to be generated to no longer throw SegmentNotFound exceptions if a unit test tests a method that relies on a previously generated Segment.

*Issue #, if available:*
#26 

*Description of changes:*
* Added SDKConfig to hold SDK-wide configuration information. In our case, whether it's enabled/disabled is kept track of. This is used by the Patcher, Recorder, and the Lambda Context to change behaviors if it's disabled. 
* For the case of the Patcher, patching does not patch any methods. 
* For the Recorder, all segment creation automatically creates DummySegments and therefore not send Segments and subsequent Subsegments to the Daemon. Using DummySegments ensures that downstream methods calls on the segment/subsegment entities don't throw exceptions.
* To deal with the _Capture_ decorator, a Dummy parent segment is automatically generated to mimic middleware segment generation.

*Testing*
* Core Patcher module should not import modules when SDK is disabled
* Each specific middleware (Flask, Django, Aiohttp) is tested to ensure that they produce DummySegments and dont send anything to the emitter. 
* Recorder should produce DummySegments and DummySubsegments
* SDKConfig should take Environment Variables over hardcoded configuration.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
