### PR TITLE
Max_trace_back = 0 returns full exception stack trace bug fix. (#120)

### DIFF
--- a/aws_xray_sdk/core/models/throwable.py
+++ b/aws_xray_sdk/core/models/throwable.py
@@ -48,7 +48,7 @@ class Throwable(object):
             setattr(exception, '_cause_id', self.id)
 
     def _normalize_stack_trace(self, stack):
-        if not stack:
+        if stack is None:
             return None
 
         self.stack = []

--- a/aws_xray_sdk/core/recorder.py
+++ b/aws_xray_sdk/core/recorder.py
@@ -160,7 +160,7 @@ class AWSXRayRecorder(object):
             self.streaming = streaming
         if streaming_threshold:
             self.streaming_threshold = streaming_threshold
-        if max_trace_back:
+        if type(max_trace_back) == int and max_trace_back >= 0:
             self.max_trace_back = max_trace_back
         if stream_sql is not None:
             self.stream_sql = stream_sql

--- a/tests/test_recorder.py
+++ b/tests/test_recorder.py
@@ -166,3 +166,24 @@ def test_in_segment_exception():
                     raise Exception('test exception')
 
     assert len(subsegment.cause['exceptions']) == 1
+
+
+def test_max_stack_trace_zero():
+    xray_recorder.configure(max_trace_back=1)
+    with pytest.raises(Exception):
+        with xray_recorder.in_segment('name') as segment_with_stack:
+            assert segment_with_stack.in_progress is True
+            assert 'exceptions' not in segment_with_stack.cause.__dict__
+            raise Exception('Test Exception')
+    assert len(segment_with_stack.cause['exceptions']) == 1
+
+    xray_recorder.configure(max_trace_back=0)
+    with pytest.raises(Exception):
+        with xray_recorder.in_segment('name') as segment_no_stack:
+            assert segment_no_stack.in_progress is True
+            assert 'exceptions' not in segment_no_stack.cause.__dict__
+            raise Exception('Test Exception')
+    assert len(segment_no_stack.cause['exceptions']) == 1
+
+    assert len(segment_with_stack.cause['exceptions'][0].stack) == 1
+    assert len(segment_no_stack.cause['exceptions'][0].stack) == 0


### PR DESCRIPTION
Check on max_trace_back in the recorder configuration now checks type as well as value >= 0
instead of pythonic variable check. 

Furthermore, fixed an issue where if an empty list was used as the argument in the Throwable type initialization that it would cause the segment serialization to fail and therefore not send the segment to the daemon at all. This was causing issues when a segment was capturing a method while the max_trace_back configuration was set to 0 since it would pass in an empty list to the Throwable type initialization.

Added unit test to ensure zero value contains no stack. Tested on my local flask application as well to ensure no other issues would occur.

*Issue #, if available:*
#120

*Description of changes:*
Explicit int type checking for recorder.configuration of variable max_stack_trace, and ensuring that the value passed in is >= 0.

Testing:
* Unit test to ensure that max_trace_back=0 configuration returns a segment with an exception stack containing an empty list.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
