### PR TITLE
add suport for IGNORE context missing strategy

### DIFF
--- a/aws_xray_sdk/core/context.py
+++ b/aws_xray_sdk/core/context.py
@@ -7,7 +7,7 @@ from .exceptions.exceptions import SegmentNotFoundException
 log = logging.getLogger(__name__)
 
 MISSING_SEGMENT_MSG = 'cannot find the current segment/subsegment, please make sure you have a segment open'
-SUPPORTED_CONTEXT_MISSING = ('RUNTIME_ERROR', 'LOG_ERROR')
+SUPPORTED_CONTEXT_MISSING = ('RUNTIME_ERROR', 'LOG_ERROR', 'IGNORE')
 CXT_MISSING_STRATEGY_KEY = 'AWS_XRAY_CONTEXT_MISSING'
 
 
@@ -116,6 +116,8 @@ class Context(object):
         if self.context_missing == 'RUNTIME_ERROR':
             log.error(MISSING_SEGMENT_MSG)
             raise SegmentNotFoundException(MISSING_SEGMENT_MSG)
+        elif self.context_missing == 'IGNORE':
+            return
         else:
             log.error(MISSING_SEGMENT_MSG)
 

--- a/docs/configurations.rst
+++ b/docs/configurations.rst
@@ -92,6 +92,7 @@ Supported strategies are:
 
 * RUNTIME_ERROR: throw an SegmentNotFoundException
 * LOG_ERROR: log an error and continue
+* IGNORE: do nothing
 
 Segment Dynamic Naming
 ----------------------


### PR DESCRIPTION
Adds a new IGNORE strategy for context missing errors.

I often found myself turning off the "aws_xray_sdk.core" in my unit test code, or when debugging a problem locally.  I thought being able to set this strategy would let me know of anything else logged from the package, but would let me silence those context missing errors I'm always gonna get when running something designed for lambda locally.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
