### PR TITLE
Renamed config module name to the global name (#129)

### DIFF
--- a/aws_xray_sdk/core/lambda_launcher.py
+++ b/aws_xray_sdk/core/lambda_launcher.py
@@ -71,7 +71,7 @@ class LambdaContext(Context):
         current_entity = self.get_trace_entity()
 
         if not self._is_subsegment(current_entity) and current_entity.initializing:
-            if sdk_config_module.sdk_enabled():
+            if global_sdk_config.sdk_enabled():
                 log.warning("Subsegment %s discarded due to Lambda worker still initializing" % subsegment.name)
             return
 


### PR DESCRIPTION
Invalid name was given and would throw an exception if the lambda context was not initialized before subsegment creation.

Added unit test to make sure code path has been tested for non-ready containers.

*Issue #, if available:*
#129 

*Description of changes:*
Renamed sdk_config_module to global_sdk_config

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
