### PR TITLE
Correctly remove password component from SQLAlchemy URLs, preventing …

### DIFF
--- a/aws_xray_sdk/ext/sqlalchemy/util/decorators.py
+++ b/aws_xray_sdk/ext/sqlalchemy/util/decorators.py
@@ -104,7 +104,7 @@ def parse_bind(bind):
             # Strip password from URL
             host_info = u.netloc.rpartition('@')[-1]
             parts = u._replace(netloc='{}@{}'.format(u.username, host_info))
-            safe_url = u.geturl()
+            safe_url = parts.geturl()
         sql = {}
         sql['database_type'] = u.scheme
         sql['url'] = safe_url


### PR DESCRIPTION
…invalid characters in SQLAlchemy subsegment names

*Issue #:* #131

*Description of changes:* 
The URL is parsed and the password stripped, but the old URL is assigned to `safe_url`. The method `ParseResult._replace` returns a new `ParseResult` but does not modify the initial `ParseResult`. This fixes the problem I described in the issue linked above where SQLAlchemy will replace the password component of SQLAlchemy URL with `***` which is then used as a Xray subsegment name, despite being invalid characters.

This is not a new feature, but a small fix to existing code which seems intended to do this in the first place. It seems the sort of thing which should require a test, but I'm not really sure how to add one that tests this since all the tests I can see use `sqlite:///:memory:` which as far as I know cannot have a password.

When I run the tests locally before this patch I have 5 failures in `tests/test_patcher.py`, when running after this patch, I get the same 5 failures.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.