### PR TITLE
Poller threads block main thread from exiting bug #134

### DIFF
--- a/aws_xray_sdk/core/sampling/rule_poller.py
+++ b/aws_xray_sdk/core/sampling/rule_poller.py
@@ -19,7 +19,9 @@ class RulePoller(object):
         self._connector = connector
 
     def start(self):
-        threading.Thread(target=self._worker).start()
+        poller_thread = threading.Thread(target=self._worker)
+        poller_thread.daemon = True
+        poller_thread.start()
 
     def _worker(self):
         frequency = 1

--- a/aws_xray_sdk/core/sampling/target_poller.py
+++ b/aws_xray_sdk/core/sampling/target_poller.py
@@ -20,7 +20,9 @@ class TargetPoller(object):
         self._interval = 10 # default 10 seconds interval on sampling targets fetch
 
     def start(self):
-        threading.Thread(target=self._worker).start()
+        poller_thread = threading.Thread(target=self._worker)
+        poller_thread.daemon = True
+        poller_thread.start()
 
     def _worker(self):
         while True:


### PR DESCRIPTION
*Issue #, if available:*
#134 

*Description of changes:*
Set poller threads as daemon threads so they dont block the main thread on exit. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
