### PR TITLE
Fix exception processing in Django running in Lambda #86

### DIFF
--- a/aws_xray_sdk/ext/django/middleware.py
+++ b/aws_xray_sdk/ext/django/middleware.py
@@ -95,7 +95,10 @@ class XRayMiddleware(object):
         Add exception information and fault flag to the
         current segment.
         """
-        segment = xray_recorder.current_segment()
+        if self.in_lambda_ctx:
+            segment = xray_recorder.current_subsegment()
+        else:
+            segment = xray_recorder.current_segment()
         segment.put_http_meta(http.STATUS, 500)
 
         stack = stacktrace.get_stacktrace(limit=xray_recorder._max_trace_back)


### PR DESCRIPTION
*Issue #, if available:*
#86 

*Description of changes:*
Exception processing in Django running in Lambda retrieves the subsegment when in Lambda, and a segment otherwise.

Testing:
* Added test case to check that faults are caught properly in Lambda

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
