### PR TITLE
Enable test with Python3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: python
-
+dist: xenial
 python:
   - "2.7"
   - "3.4"

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
   - "3.4"
   - "3.5"
   - "3.6"
+  - "3.7"
 
 install:
   - pip install tox

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,7 @@
 [tox]
 envlist =
-    py{27,34,35,36}
-    py36-aiohttp2
-    py35-aiohttp2
+    py{27,34,35,36,37}
+    py{35,36,37}-aiohttp2
     coverage-report
 
 skip_missing_interpreters = True
@@ -28,13 +27,13 @@ deps =
     py{27}: enum34
 
     # Python3.5+ only deps
-    py{35,36}: aiohttp >= 3.0.0
-    py{35,36}: pytest-aiohttp
-    py{35,36}: aiobotocore >= 0.10.0
+    py{35,36,37}: aiohttp >= 3.0.0
+    py{35,36,37}: pytest-aiohttp
+    py{35,36,37}: aiobotocore >= 0.10.0
 
 commands =
     py{27,34}: coverage run --source aws_xray_sdk -m py.test tests --ignore tests/ext/aiohttp --ignore tests/ext/aiobotocore --ignore tests/test_async_local_storage.py --ignore tests/test_async_recorder.py
-    py{35,36}: coverage run --source aws_xray_sdk -m py.test tests
+    py{35,36,37}: coverage run --source aws_xray_sdk -m py.test tests
 
 setenv =
     DJANGO_SETTINGS_MODULE = tests.ext.django.app.settings
@@ -63,13 +62,24 @@ deps =
 commands =
     py{36}: coverage run --source aws_xray_sdk -m py.test tests/ext/aiohttp --ignore tests/ext/aiohttp/test_client.py
 
+[testenv:py37-aiohttp2]
+deps =
+    pytest > 3.0.0
+    aiohttp >= 2.3.0,<3.0.0
+    pytest-aiohttp
+    botocore
+    coverage
+
+commands =
+    py{37}: coverage run --source aws_xray_sdk -m py.test tests/ext/aiohttp --ignore tests/ext/aiohttp/test_client.py
+
 [testenv:coverage-report]
 deps = coverage
 skip_install = true
 commands =
     # might need to add coverage combine at some point
-    py{36}: coverage report
-    py{36}: coverage html
+    py{37}: coverage report
+    py{37}: coverage html
 
 [flake8]
 max-line-length=120


### PR DESCRIPTION
*Issue*: 
#156 

In November of last year, AWS Lambda included official support for Python3.7 on Lambda, however, this project is not being tested using Python3.7.

*Description of changes:* 

- Change the Travis-ci configuration to use Ubuntu Xenial (16.04) instead of Ubuntu Trusty (14.04) as base OS to allow run the tests with Python3.7.  Python 3.7 is not available on Ubuntu 14.04, and 14.04 already reached the End of Life status.
- Update the 'tox' configurations and Travis-ci configuration to enable test with Python3.7


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
