### PR TITLE
Fixes unit test for newer versions of psycopg2.

### DIFF
--- a/tests/ext/psycopg2/test_psycopg2.py
+++ b/tests/ext/psycopg2/test_psycopg2.py
@@ -144,7 +144,7 @@ def test_execute_bad_query():
     assert sql['database_version']
 
     exception = subsegment.cause['exceptions'][0]
-    assert exception.type == 'ProgrammingError'
+    assert exception.type == 'UndefinedColumn'
 
 
 def test_register_extensions():


### PR DESCRIPTION
Version 2.8.0 of Psycopg2 introduces granular errors for queries. This commit fixes a unit test to assert on the specific error instead of the now-updated base class. Functionally, the patcher still works fine with the latest versions of Psycopg2.

The previous matching class was ProgrammingError. For the specific test, it is now UndefinedColumn, which is a subclass of ProgrammingError.

*Issue #, if available:*
#159 

*Description of changes:*
Modified test to check for UndefinedColumn instead of ProgrammingError.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
