### PR TITLE
Fix patching for PynamoDB 4.x with botocore 1.13

### DIFF
--- a/aws_xray_sdk/ext/pynamodb/patch.py
+++ b/aws_xray_sdk/ext/pynamodb/patch.py
@@ -8,15 +8,23 @@ from aws_xray_sdk.ext.boto_utils import _extract_whitelisted_params
 
 PYNAMODB4 = int(pynamodb.__version__.split('.')[0]) >= 4
 
+if PYNAMODB4:
+    import botocore.httpsession
+else:
+    import botocore.vendored.requests.sessions
+
 
 def patch():
     """Patch PynamoDB so it generates subsegements when calling DynamoDB."""
 
     if PYNAMODB4:
+        if hasattr(botocore.httpsession, '_xray_enabled'):
+            return
+        setattr(botocore.httpsession, '_xray_enabled', True)
+
         module = 'botocore.httpsession'
         name = 'URLLib3Session.send'
     else:
-        import botocore.vendored.requests.sessions
         if hasattr(botocore.vendored.requests.sessions, '_xray_enabled'):
             return
         setattr(botocore.vendored.requests.sessions, '_xray_enabled', True)


### PR DESCRIPTION
Fixes #179 

Patching PynamoDB broke when using `botocore` 1.13, as this version of `botocore` doesn't ship `requests` anymore. While the vendored `requests` library is a requirement for PynamoDB <4.0, it's not for PynamoDB >=4.0. Therefore only import and patch `botocore.vendored.requests.sessions` when using PynamoDB <4.0.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
