### PR TITLE
Add an option to force a normal context on Lambda

### DIFF
--- a/aws_xray_sdk/core/lambda_launcher.py
+++ b/aws_xray_sdk/core/lambda_launcher.py
@@ -21,6 +21,11 @@ def check_in_lambda():
     Return None if SDK is not loaded in AWS Lambda worker.
     Otherwise drop a touch file and return a lambda context.
     """
+
+    override_context = os.getenv('XRAY_OVERRIDE_CONTEXT')
+    if override_context == 'normal':
+        return None
+
     if not os.getenv(LAMBDA_TASK_ROOT_KEY):
         return None
 


### PR DESCRIPTION
Detect in `check_in_lambda` if an environment variable (SDK config level) is set and return early if its value is `normal`.

This will make the recorder use a plain `Context` object, instead of a `LambdaContext` object.

The rationale for this: I need to report the URL in the top segment for a server-less application I'm working on. I want to analyse some GraphQL queries in the console and I need their name in the URL, to classify them. If I enable X-Ray reporting in the Lambda console, a top segment is created and I'm unable to change its URL field (as said in the docs). But if I disable X-Ray to create the segment by myself (loosing cold-start info is ok in my case) the SDK still thinks a LambdaContext should be used. With a `LambdaContext` you cannot create top segments. This change allows the user of the SDK to override the kind of context used.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.