### PR TITLE
Whitelist SageMakerRuntime InvokeEndpoint operation

### DIFF
--- a/aws_xray_sdk/ext/resources/aws_para_whitelist.json
+++ b/aws_xray_sdk/ext/resources/aws_para_whitelist.json
@@ -901,6 +901,15 @@
           }
         }
       }
+    },
+    "runtime.sagemaker": {
+      "operations": {
+        "InvokeEndpoint": {
+          "request_parameters": [
+            "EndpointName"
+          ]
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
Operation name and request param acquired from this documentation:
https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/sagemaker-runtime.html#SageMakerRuntime.Client.invoke_endpoint

Sample subsegment from end-to-end test, works as expected:
```
{
    "id": "fc174e725fa660c3",
    "name": "SageMakerRuntime",
    "start_time": 1573676110.9078012,
    "end_time": 1573676110.98827,
    "http": {
        "response": {
            "status": 200
        }
    },
    "aws": {
        "endpoint_name": "test-endpoint-2",
        "operation": "InvokeEndpoint",
        "region": "us-east-1",
        "request_id": "16e2f384-dbf0-4ba7-b94a-7b70f511b476",
        "resource_names": [
            "test-endpoint-2"
        ]
    },
    "namespace": "aws"
}
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
