### PR TITLE
Downgrade Coverage to 4.5.4

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ skip_missing_interpreters = True
 passenv = TOXENV CI TRAVIS TRAVIS_* CODECOV_*
 deps =
     pytest > 3.0.0
-    coverage
+    coverage==4.5.4
     codecov
     requests
     flask >= 0.10
@@ -50,7 +50,7 @@ deps =
     aiohttp >= 2.3.0,<3.0.0
     pytest-aiohttp
     botocore
-    coverage
+    coverage==4.5.4
 
 commands =
     py{35}: coverage run --source aws_xray_sdk -m py.test tests/ext/aiohttp --ignore tests/ext/aiohttp/test_client.py
@@ -61,7 +61,7 @@ deps =
     aiohttp >= 2.3.0,<3.0.0
     pytest-aiohttp
     botocore
-    coverage
+    coverage==4.5.4
 
 commands =
     py{36}: coverage run --source aws_xray_sdk -m py.test tests/ext/aiohttp --ignore tests/ext/aiohttp/test_client.py
@@ -72,7 +72,7 @@ deps =
     aiohttp >= 2.3.0,<3.0.0
     pytest-aiohttp
     botocore
-    coverage
+    coverage==4.5.4
 
 commands =
     py{37}: coverage run --source aws_xray_sdk -m py.test tests/ext/aiohttp --ignore tests/ext/aiohttp/test_client.py
@@ -83,7 +83,7 @@ deps =
     aiohttp >= 3.6
     pytest-aiohttp
     botocore
-    coverage
+    coverage==4.5.4
 
 commands =
     py{38}: coverage run --source aws_xray_sdk -m py.test tests/ext/aiohttp --ignore tests/ext/aiohttp/test_client.py


### PR DESCRIPTION
Coverage 5.0 had introduced a bug for us and is causing our tox tests to throw a
Segment Missing Exception upon starting coverage. Downgrading to 4.5.4 while we
investigate the root cause.

*Issue #, if available:*
#195 

*Description of changes:*
Downgraded coverage to 4.5.4

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
