### PR TITLE
Unwrap context provided to psycopg2.extensions.quote_ident

### DIFF
--- a/aws_xray_sdk/ext/psycopg2/patch.py
+++ b/aws_xray_sdk/ext/psycopg2/patch.py
@@ -18,6 +18,11 @@ def patch():
         'register_type',
         _xray_register_type_fix
     )
+    wrapt.wrap_function_wrapper(
+        'psycopg2.extensions',
+        'quote_ident',
+        _xray_register_type_fix
+    )
 
 
 def _xray_traced_connect(wrapped, instance, args, kwargs):

--- a/tests/ext/psycopg2/test_psycopg2.py
+++ b/tests/ext/psycopg2/test_psycopg2.py
@@ -1,6 +1,7 @@
 import psycopg2
 import psycopg2.extras
 import psycopg2.pool
+import psycopg2.sql
 
 import pytest
 import testing.postgresql
@@ -158,3 +159,17 @@ def test_register_extensions():
                                 ' user=' + dsn['user'])
         assert psycopg2.extras.register_uuid(None, conn)
         assert psycopg2.extras.register_uuid(None, conn.cursor())
+
+
+def test_query_as_string():
+    with testing.postgresql.Postgresql() as postgresql:
+        url = postgresql.url()
+        dsn = postgresql.dsn()
+        conn = psycopg2.connect('dbname=' + dsn['database'] +
+                                ' password=mypassword' +
+                                ' host=' + dsn['host'] +
+                                ' port=' + str(dsn['port']) +
+                                ' user=' + dsn['user'])
+        test_sql = psycopg2.sql.Identifier('test')
+        assert test_sql.as_string(conn)
+        assert test_sql.as_string(conn.cursor())


### PR DESCRIPTION
This PR fixes a bug in the use of `psycopg2.extensions.quote_ident` when psycopg2 is patched by this SDK. The bug is similar to the one fixed by #95, where a wrapped cursor or connection [causes a type error](https://github.com/psycopg/psycopg2/blob/master/psycopg/psycopgmodule.c#L180).

The [new test case](https://github.com/UnitedIncome/aws-xray-sdk-python/blob/a83b482530b72bf49235568d2dfc252422de3f32/tests/ext/psycopg2/test_psycopg2.py#L164) gives a minimal example of the bug, which fails against the current master ([4689220](https://github.com/aws/aws-xray-sdk-python/tree/46892208561107405d68e64b3423eea54e7b8127)).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
