### PR TITLE
Add support for Django 2.0 to 3.0

### DIFF
--- a/aws_xray_sdk/ext/django/templates.py
+++ b/aws_xray_sdk/ext/django/templates.py
@@ -1,6 +1,7 @@
 import logging
 
 from django.template import Template
+from django.utils.safestring import SafeString
 
 from aws_xray_sdk.core import xray_recorder
 
@@ -22,6 +23,10 @@ def patch_template():
         template_name = self.name or getattr(context, 'template_name', None)
         if template_name:
             name = str(template_name)
+            # SafeString are not properly serialized by jsonpickle,
+            # turn them back to str by adding a non-safe str.
+            if isinstance(name, SafeString):
+                name += ''
             subsegment = xray_recorder.current_subsegment()
             if subsegment:
                 subsegment.name = name

--- a/tests/ext/django/app/settings.py
+++ b/tests/ext/django/app/settings.py
@@ -44,7 +44,6 @@ MIDDLEWARE = [
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
-    'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'django.middleware.security.SecurityMiddleware',

--- a/tests/ext/django/app/templates/block.html
+++ b/tests/ext/django/app/templates/block.html
@@ -1,0 +1,1 @@
+<p>Hello World</p>

--- a/tests/ext/django/app/templates/block_user.html
+++ b/tests/ext/django/app/templates/block_user.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<body>
+
+<h1>Django Test App</h1>
+
+{% include "block.html" %}
+
+</body>
+</html>

--- a/tests/ext/django/app/views.py
+++ b/tests/ext/django/app/views.py
@@ -9,6 +9,10 @@ class IndexView(TemplateView):
     template_name = 'index.html'
 
 
+class TemplateBlockView(TemplateView):
+    template_name = 'block_user.html'
+
+
 def ok(request):
     return HttpResponse(status=200)
 
@@ -32,4 +36,5 @@ urlpatterns = [
     url(r'^500fault/$', fault, name='500fault'),
     url(r'^call_db/$', call_db, name='call_db'),
     url(r'^template/$', IndexView.as_view(), name='template'),
+    url(r'^template_block/$', TemplateBlockView.as_view(), name='template_block'),
 ]

--- a/tests/ext/django/test_middleware.py
+++ b/tests/ext/django/test_middleware.py
@@ -1,6 +1,6 @@
 import django
 from aws_xray_sdk import global_sdk_config
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.test import TestCase
 
 from aws_xray_sdk.core import xray_recorder, lambda_launcher

--- a/tests/ext/django/test_middleware.py
+++ b/tests/ext/django/test_middleware.py
@@ -90,6 +90,17 @@ class XRayTestCase(TestCase):
         assert not subsegment.in_progress
         assert subsegment.namespace == 'local'
 
+    def test_template_block(self):
+        url = reverse('template_block')
+        self.client.get(url)
+        segment = xray_recorder.emitter.pop()
+        assert len(segment.subsegments) == 1
+
+        subsegment = segment.subsegments[0]
+        assert subsegment.name == 'block_user.html'
+        assert not subsegment.in_progress
+        assert subsegment.namespace == 'local'
+
     def test_trace_header_data_perservation(self):
         url = reverse('200ok')
         self.client.get(url, HTTP_X_AMZN_TRACE_ID='k1=v1')

--- a/tox.ini
+++ b/tox.ini
@@ -21,9 +21,9 @@ deps =
     Flask-SQLAlchemy
     future
     # the sdk doesn't support earlier version of django
-    django1: django >= 1.10, <2.0
-    django2: django >= 2.2, <2.3
-    !django1-!django2: django >= 3.0, <4.0
+    py{27,34}-!django2-!django3,django1: django >= 1.10, <2.0
+    py{35}-!django1-!django3,django2: django >= 2.2, <2.3
+    py{36,37,38}-!django1-!django2,django3: django >= 3.0, <4.0
     django-fake-model
     pynamodb >= 3.3.1
     psycopg2

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,9 @@
 [tox]
 envlist =
-    py{27,34,35,36,37,38}
+    py{27,34,35,36,37,38}-django1
     py{35,36,37,38}-aiohttp2
+    py{35,36,37,38}-django2
+    py{36,37,38}-django3
     coverage-report
 
 skip_missing_interpreters = True
@@ -19,7 +21,9 @@ deps =
     Flask-SQLAlchemy
     future
     # the sdk doesn't support earlier version of django
-    django >= 1.10, <2.0
+    django1: django >= 1.10, <2.0
+    django2: django >= 2.2, <2.3
+    django3: django >= 3.0, <4.0
     django-fake-model
     pynamodb >= 3.3.1
     psycopg2

--- a/tox.ini
+++ b/tox.ini
@@ -23,7 +23,7 @@ deps =
     # the sdk doesn't support earlier version of django
     django1: django >= 1.10, <2.0
     django2: django >= 2.2, <2.3
-    django3: django >= 3.0, <4.0
+    !django1-!django2: django >= 3.0, <4.0
     django-fake-model
     pynamodb >= 3.3.1
     psycopg2

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,7 @@
 [tox]
 envlist =
-    py{27,34,35,36,37,38}-django1
+    py{27,34,35,36,37,38}
     py{35,36,37,38}-aiohttp2
-    py{35,36,37,38}-django2
-    py{36,37,38}-django3
     coverage-report
 
 skip_missing_interpreters = True
@@ -21,9 +19,7 @@ deps =
     Flask-SQLAlchemy
     future
     # the sdk doesn't support earlier version of django
-    py{27,34}-!django2-!django3,django1: django >= 1.10, <2.0
-    py{35}-!django1-!django3,django2: django >= 2.2, <2.3
-    py{36,37,38}-!django1-!django2,django3: django >= 3.0, <4.0
+    django >= 1.10
     django-fake-model
     pynamodb >= 3.3.1
     psycopg2


### PR DESCRIPTION
This fixes a runtime issue with template names in subsegments (#168) and two failed imports during tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
