### PR TITLE
add puttracesegments to boto whitelist avoid a catch 22

### DIFF
--- a/aws_xray_sdk/ext/botocore/patch.py
+++ b/aws_xray_sdk/ext/botocore/patch.py
@@ -31,7 +31,9 @@ def _xray_traced_botocore(wrapped, instance, args, kwargs):
     service = instance._service_model.metadata["endpointPrefix"]
     if service == 'xray':
         # skip tracing for SDK built-in sampling pollers
-        if 'GetSamplingRules' in args or 'GetSamplingTargets' in args:
+        if ('GetSamplingRules' in args or
+            'GetSamplingTargets' in args or
+                'PutTraceSegments' in args):
             return wrapped(*args, **kwargs)
     return xray_recorder.record_subsegment(
         wrapped, instance, args, kwargs,


### PR DESCRIPTION
*Issue #, if available:*
closes #207 

*Description of changes:*
whitelist putting tracesegments to xray to avoid a catch 22 when the segment is closed.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
