### PR TITLE
Add patch support for pymysql (pure Python driver)

### DIFF
--- a/aws_xray_sdk/core/patcher.py
+++ b/aws_xray_sdk/core/patcher.py
@@ -21,6 +21,7 @@ SUPPORTED_MODULES = (
     'mysql',
     'httplib',
     'pymongo',
+    'pymysql',
     'psycopg2',
     'pg8000',
 )
@@ -33,6 +34,7 @@ NO_DOUBLE_PATCH = (
     'sqlite3',
     'mysql',
     'pymongo',
+    'pymysql',
     'psycopg2',
     'pg8000',
 )

--- a/aws_xray_sdk/ext/pymysql/__init__.py
+++ b/aws_xray_sdk/ext/pymysql/__init__.py
@@ -1,0 +1,4 @@
+from .patch import patch
+
+
+__all__ = ['patch']

--- a/aws_xray_sdk/ext/pymysql/__init__.py
+++ b/aws_xray_sdk/ext/pymysql/__init__.py
@@ -1,4 +1,4 @@
-from .patch import patch
+from .patch import patch, unpatch
 
 
-__all__ = ['patch']
+__all__ = ['patch', 'unpatch']

--- a/aws_xray_sdk/ext/pymysql/patch.py
+++ b/aws_xray_sdk/ext/pymysql/patch.py
@@ -32,8 +32,8 @@ def _xray_traced_connect(wrapped, instance, args, kwargs):
         if hasattr(conn, attr):
             meta[key] = getattr(conn, attr)
 
-    if hasattr(conn, '_server_version'):
-        version = sanitize_db_ver(getattr(conn, '_server_version'))
+    if hasattr(conn, 'server_version'):
+        version = sanitize_db_ver(getattr(conn, 'server_version'))
         if version:
             meta['database_version'] = version
 

--- a/aws_xray_sdk/ext/pymysql/patch.py
+++ b/aws_xray_sdk/ext/pymysql/patch.py
@@ -1,0 +1,48 @@
+import wrapt
+import pymysql
+
+from aws_xray_sdk.ext.dbapi2 import XRayTracedConn
+
+
+MYSQL_ATTR = {
+    '_host': 'name',
+    '_user': 'user',
+}
+
+
+def patch():
+
+    wrapt.wrap_function_wrapper(
+        'pymysql',
+        'connect',
+        _xray_traced_connect
+    )
+
+    # patch alias
+    if hasattr(pymysql, 'Connect'):
+        pymysql.Connect = pymysql.connect
+
+
+def _xray_traced_connect(wrapped, instance, args, kwargs):
+
+    conn = wrapped(*args, **kwargs)
+    meta = {}
+
+    for attr, key in MYSQL_ATTR.items():
+        if hasattr(conn, attr):
+            meta[key] = getattr(conn, attr)
+
+    if hasattr(conn, 'server_version'):
+        version = sanitize_db_ver(getattr(conn, 'server_version'))
+        if version:
+            meta['database_version'] = version
+
+    return XRayTracedConn(conn, meta)
+
+
+def sanitize_db_ver(raw):
+
+    if not raw or not isinstance(raw, tuple):
+        return raw
+
+    return '.'.join(str(num) for num in raw)

--- a/aws_xray_sdk/ext/pymysql/patch.py
+++ b/aws_xray_sdk/ext/pymysql/patch.py
@@ -1,15 +1,9 @@
-import wrapt
 import pymysql
+import wrapt
 
 from aws_xray_sdk.ext.dbapi2 import XRayTracedConn
 from aws_xray_sdk.core.patcher import _PATCHED_MODULES
 from aws_xray_sdk.ext.util import unwrap
-
-
-MYSQL_ATTR = {
-    '_host': 'name',
-    '_user': 'user',
-}
 
 
 def patch():
@@ -28,11 +22,11 @@ def patch():
 def _xray_traced_connect(wrapped, instance, args, kwargs):
 
     conn = wrapped(*args, **kwargs)
-    meta = {}
-
-    for attr, key in MYSQL_ATTR.items():
-        if hasattr(conn, attr):
-            meta[key] = getattr(conn, attr)
+    meta = {
+        'database_type': 'MySQL',
+        'user': conn.user.decode('utf-8'),
+        'driver_version': 'PyMySQL'
+    }
 
     if hasattr(conn, 'server_version'):
         version = sanitize_db_ver(getattr(conn, 'server_version'))

--- a/aws_xray_sdk/ext/pymysql/patch.py
+++ b/aws_xray_sdk/ext/pymysql/patch.py
@@ -2,6 +2,8 @@ import wrapt
 import pymysql
 
 from aws_xray_sdk.ext.dbapi2 import XRayTracedConn
+from aws_xray_sdk.core.patcher import _PATCHED_MODULES
+from aws_xray_sdk.ext.util import unwrap
 
 
 MYSQL_ATTR = {
@@ -46,3 +48,12 @@ def sanitize_db_ver(raw):
         return raw
 
     return '.'.join(str(num) for num in raw)
+
+
+def unpatch():
+    """
+    Unpatch any previously patched modules.
+    This operation is idempotent.
+    """
+    _PATCHED_MODULES.discard('pymysql')
+    unwrap(pymysql, 'connect')

--- a/aws_xray_sdk/ext/pymysql/patch.py
+++ b/aws_xray_sdk/ext/pymysql/patch.py
@@ -32,8 +32,8 @@ def _xray_traced_connect(wrapped, instance, args, kwargs):
         if hasattr(conn, attr):
             meta[key] = getattr(conn, attr)
 
-    if hasattr(conn, 'server_version'):
-        version = sanitize_db_ver(getattr(conn, 'server_version'))
+    if hasattr(conn, '_server_version'):
+        version = sanitize_db_ver(getattr(conn, '_server_version'))
         if version:
             meta['database_version'] = version
 

--- a/tests/ext/pymysql/test_pymysql.py
+++ b/tests/ext/pymysql/test_pymysql.py
@@ -29,7 +29,7 @@ def test_execute_dsn_kwargs():
     with testing.mysqld.Mysqld() as mysqld:
         dsn = mysqld.dsn()
         conn = pymysql.connect(
-            database=dsn["database"],
+            database=dsn["db"],
             user=dsn["user"],
             password="",
             host=dsn["host"],
@@ -52,7 +52,7 @@ def test_execute_bad_query():
     with testing.mysqld.Mysqld() as mysqld:
         dsn = mysqld.dsn()
         conn = pymysql.connect(
-            database=dsn["database"],
+            database=dsn["db"],
             user=dsn["user"],
             password="",
             host=dsn["host"],

--- a/tests/ext/pymysql/test_pymysql.py
+++ b/tests/ext/pymysql/test_pymysql.py
@@ -34,7 +34,7 @@ def test_execute_dsn_kwargs():
     q = 'SELECT 1'
     with testing.mysqld.Mysqld() as mysqld:
         dsn = mysqld.dsn()
-        conn = pg8000.connect(database=dsn['db'],
+        conn = pymysql.connect(database=dsn['db'],
                               user=dsn['user'],
                               password='',
                               host=dsn['host'],
@@ -54,7 +54,7 @@ def test_execute_bad_query():
     q = "SELECT blarg"
     with testing.mysqld.Mysqld() as mysqld:
         dsn = mysqld.dsn()
-        conn = pg8000.connect(database=dsn['db'],
+        conn = pymysql.connect(database=dsn['db'],
                               user=dsn['user'],
                               password='',
                               host=dsn['host'],

--- a/tests/ext/pymysql/test_pymysql.py
+++ b/tests/ext/pymysql/test_pymysql.py
@@ -1,0 +1,75 @@
+import pymysql
+
+import pytest
+import testing.mysqld
+
+from aws_xray_sdk.core import patch, xray_recorder
+from aws_xray_sdk.core.context import Context
+from aws_xray_sdk.ext.pymysql import unpatch
+
+
+@pytest.fixture(autouse=True)
+def construct_ctx():
+    """
+    Clean up context storage on each test run and begin a segment
+    so that later subsegment can be attached. After each test run
+    it cleans up context storage again.
+    """
+    patch(("pymysql",))
+    xray_recorder.configure(service="test", sampling=False, context=Context())
+    xray_recorder.clear_trace_entities()
+    xray_recorder.begin_segment("name")
+    yield
+    xray_recorder.clear_trace_entities()
+    unpatch()
+
+
+def test_execute_dsn_kwargs():
+    q = "SELECT 1"
+    with testing.mysqld.Mysqld() as mysqld:
+        dsn = mysqld.dsn()
+        conn = pymysql.connect(
+            database=dsn["database"],
+            user=dsn["user"],
+            password="",
+            host=dsn["host"],
+            port=dsn["port"],
+        )
+
+        cur = conn.cursor()
+        cur.execute(q)
+
+    subsegment = xray_recorder.current_segment().subsegments[-1]
+    assert subsegment.name == "execute"
+    sql = subsegment.sql
+    assert sql["database_type"] == "pymysql"
+    assert sql["user"] == dsn["user"]
+    assert sql["database_version"]
+
+
+def test_execute_bad_query():
+    q = "SELECT blarg"
+    with testing.mysqld.Mysqld() as mysqld:
+        dsn = mysqld.dsn()
+        conn = pymysql.connect(
+            database=dsn["database"],
+            user=dsn["user"],
+            password="",
+            host=dsn["host"],
+            port=dsn["port"],
+        )
+        cur = conn.cursor()
+        try:
+            cur.execute(q)
+        except Exception:
+            pass
+
+    subsegment = xray_recorder.current_segment().subsegments[-1]
+    assert subsegment.name == "execute"
+    sql = subsegment.sql
+    assert sql["database_type"] == "pymysql"
+    assert sql["user"] == dsn["user"]
+    assert sql["database_version"]
+
+    exception = subsegment.cause["exceptions"][0]
+    assert exception.type == "InternalError"

--- a/tests/ext/pymysql/test_pymysql.py
+++ b/tests/ext/pymysql/test_pymysql.py
@@ -47,6 +47,7 @@ def test_execute_dsn_kwargs():
     sql = subsegment.sql
     assert sql['database_type'] == 'MySQL'
     assert sql['user'] == dsn['user']
+    assert sql['driver_version'] == 'PyMySql'
     assert sql['database_version']
 
 
@@ -71,6 +72,7 @@ def test_execute_bad_query():
     sql = subsegment.sql
     assert sql['database_type'] == 'MySQL'
     assert sql['user'] == dsn['user']
+    assert sql['driver_version'] == 'PyMySql'
     assert sql['database_version']
 
     exception = subsegment.cause['exceptions'][0]

--- a/tests/ext/pymysql/test_pymysql.py
+++ b/tests/ext/pymysql/test_pymysql.py
@@ -3,9 +3,17 @@ import pymysql
 import pytest
 import testing.mysqld
 
-from aws_xray_sdk.core import patch, xray_recorder
+from aws_xray_sdk.core import patch
+from aws_xray_sdk.core import xray_recorder
 from aws_xray_sdk.core.context import Context
 from aws_xray_sdk.ext.pymysql import unpatch
+
+
+@pytest.fixture(scope='module', autouse=True)
+def patch_module():
+    patch(('pymysql',))
+    yield
+    unpatch()
 
 
 @pytest.fixture(autouse=True)
@@ -15,49 +23,43 @@ def construct_ctx():
     so that later subsegment can be attached. After each test run
     it cleans up context storage again.
     """
-    patch(("pymysql",))
-    xray_recorder.configure(service="test", sampling=False, context=Context())
+    xray_recorder.configure(service='test', sampling=False, context=Context())
     xray_recorder.clear_trace_entities()
-    xray_recorder.begin_segment("name")
+    xray_recorder.begin_segment('name')
     yield
     xray_recorder.clear_trace_entities()
-    unpatch()
 
 
 def test_execute_dsn_kwargs():
-    q = "SELECT 1"
+    q = 'SELECT 1'
     with testing.mysqld.Mysqld() as mysqld:
         dsn = mysqld.dsn()
-        conn = pymysql.connect(
-            database=dsn["db"],
-            user=dsn["user"],
-            password="",
-            host=dsn["host"],
-            port=dsn["port"],
-        )
-
+        conn = pg8000.connect(database=dsn['db'],
+                              user=dsn['user'],
+                              password='',
+                              host=dsn['host'],
+                              port=dsn['port'])
         cur = conn.cursor()
         cur.execute(q)
 
     subsegment = xray_recorder.current_segment().subsegments[-1]
-    assert subsegment.name == "execute"
+    assert subsegment.name == 'execute'
     sql = subsegment.sql
-    assert sql["database_type"] == "pymysql"
-    assert sql["user"] == dsn["user"]
-    assert sql["database_version"]
+    assert sql['database_type'] == 'MySQL'
+    assert sql['user'] == dsn['user']
+    assert sql['database_version']
 
 
 def test_execute_bad_query():
     q = "SELECT blarg"
     with testing.mysqld.Mysqld() as mysqld:
         dsn = mysqld.dsn()
-        conn = pymysql.connect(
-            database=dsn["db"],
-            user=dsn["user"],
-            password="",
-            host=dsn["host"],
-            port=dsn["port"],
-        )
+        conn = pg8000.connect(database=dsn['db'],
+                              user=dsn['user'],
+                              password='',
+                              host=dsn['host'],
+                              port=dsn['port'])
+
         cur = conn.cursor()
         try:
             cur.execute(q)
@@ -67,9 +69,9 @@ def test_execute_bad_query():
     subsegment = xray_recorder.current_segment().subsegments[-1]
     assert subsegment.name == "execute"
     sql = subsegment.sql
-    assert sql["database_type"] == "pymysql"
-    assert sql["user"] == dsn["user"]
-    assert sql["database_version"]
+    assert sql['database_type'] == 'MySQL'
+    assert sql['user'] == dsn['user']
+    assert sql['database_version']
 
-    exception = subsegment.cause["exceptions"][0]
-    assert exception.type == "InternalError"
+    exception = subsegment.cause['exceptions'][0]
+    assert exception.type == 'InternalError'

--- a/tests/ext/pymysql/test_pymysql.py
+++ b/tests/ext/pymysql/test_pymysql.py
@@ -47,7 +47,7 @@ def test_execute_dsn_kwargs():
     sql = subsegment.sql
     assert sql['database_type'] == 'MySQL'
     assert sql['user'] == dsn['user']
-    assert sql['driver_version'] == 'PyMySql'
+    assert sql['driver_version'] == 'PyMySQL'
     assert sql['database_version']
 
 
@@ -72,7 +72,7 @@ def test_execute_bad_query():
     sql = subsegment.sql
     assert sql['database_type'] == 'MySQL'
     assert sql['user'] == dsn['user']
-    assert sql['driver_version'] == 'PyMySql'
+    assert sql['driver_version'] == 'PyMySQL'
     assert sql['database_version']
 
     exception = subsegment.cause['exceptions'][0]

--- a/tox.ini
+++ b/tox.ini
@@ -22,9 +22,11 @@ deps =
     django >= 1.10
     django-fake-model
     pynamodb >= 3.3.1
+    pymysql
     psycopg2
     pg8000
     testing.postgresql
+    testing.mysqld
     webtest
 
     # Python2 only deps


### PR DESCRIPTION
*Issue #214*

*Description of changes:*
Added patch support for `pymysql` client library (written in python) for MySQL.

TODO:
- [x] Add `unpatch` method
- [x] Add tests (Use: [this](https://pypi.org/project/testing.mysqld/))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
