### PR TITLE
Added proper TraceID in dummy segments

### DIFF
--- a/aws_xray_sdk/core/models/dummy_entities.py
+++ b/aws_xray_sdk/core/models/dummy_entities.py
@@ -1,3 +1,4 @@
+from .traceid import TraceId
 from .segment import Segment
 from .subsegment import Subsegment
 
@@ -13,7 +14,7 @@ class DummySegment(Segment):
     """
     def __init__(self, name='dummy'):
 
-        super(DummySegment, self).__init__(name=name, traceid='dummy')
+        super(DummySegment, self).__init__(name=name, traceid=TraceId().to_id())
         self.sampled = False
 
     def set_aws(self, aws_meta):

--- a/tests/test_dummy_entites.py
+++ b/tests/test_dummy_entites.py
@@ -3,7 +3,6 @@ from aws_xray_sdk.core.models import http
 
 
 def test_not_sampled():
-
     segment = DummySegment()
     subsegment = DummySubsegment(segment)
 
@@ -12,7 +11,6 @@ def test_not_sampled():
 
 
 def test_no_ops():
-
     segment = DummySegment()
     segment.put_metadata('key', 'value')
     segment.put_annotation('key', 'value')
@@ -63,3 +61,12 @@ def test_invalid_entity_name():
 
     assert segment.name == 'DummySegment Test'
     assert subsegment.name == 'DummySubsegment'
+
+
+def test_dummy_segment_trace_id():
+    segment = DummySegment()
+
+    assert segment.trace_id != 'dummy'
+    assert '-' in segment.trace_id
+    # checking version of trace id
+    assert segment.trace_id[:1] == '1'


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Added call to generate proper TraceID in Dummy Segment case. Tested this change with listQueues AWS SDK downstream call. 
 
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
