### PR TITLE
Using instance doc to fetch EC2 metadata. Added 2 additional fields

### DIFF
--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -18,26 +18,36 @@ def test_runtime_context_available():
 
 @patch('aws_xray_sdk.core.plugins.ec2_plugin.do_request')
 def test_ec2_plugin_imdsv2_success(mock_do_request):
-    mock_do_request.side_effect = ['token', 'i-0a1d026d92d4709cd', 'us-west-2b']
+    v2_json_str = "{\"availabilityZone\" : \"us-east-2a\", \"imageId\" : \"ami-03cca83dd001d4666\"," \
+               " \"instanceId\" : \"i-07a181803de94c666\", \"instanceType\" : \"t3.xlarge\"}"
+
+    mock_do_request.side_effect = ['token', v2_json_str]
 
     ec2_plugin = get_plugin_modules(('ec2_plugin',))[0]
     ec2_plugin.initialize()
     assert hasattr(ec2_plugin, 'runtime_context')
     r_c = getattr(ec2_plugin, 'runtime_context')
-    assert r_c['instance_id'] == 'i-0a1d026d92d4709cd'
-    assert r_c['availability_zone'] == 'us-west-2b'
+    assert r_c['instance_id'] == 'i-07a181803de94c666'
+    assert r_c['availability_zone'] == 'us-east-2a'
+    assert r_c['instance_type'] == 't3.xlarge'
+    assert r_c['ami_id'] == 'ami-03cca83dd001d4666'
 
 
 @patch('aws_xray_sdk.core.plugins.ec2_plugin.do_request')
 def test_ec2_plugin_v2_fail_v1_success(mock_do_request):
-    mock_do_request.side_effect = [Exception("Boom!"), 'i-0a1d026d92d4709ab', 'us-west-2a']
+    v1_json_str = "{\"availabilityZone\" : \"cn-north-1a\", \"imageId\" : \"ami-03cca83dd001d4111\"," \
+                  " \"instanceId\" : \"i-07a181803de94c111\", \"instanceType\" : \"t2.xlarge\"}"
+
+    mock_do_request.side_effect = [Exception("Boom!"), v1_json_str]
 
     ec2_plugin = get_plugin_modules(('ec2_plugin',))[0]
     ec2_plugin.initialize()
     assert hasattr(ec2_plugin, 'runtime_context')
     r_c = getattr(ec2_plugin, 'runtime_context')
-    assert r_c['instance_id'] == 'i-0a1d026d92d4709ab'
-    assert r_c['availability_zone'] == 'us-west-2a'
+    assert r_c['instance_id'] == 'i-07a181803de94c111'
+    assert r_c['availability_zone'] == 'cn-north-1a'
+    assert r_c['instance_type'] == 't2.xlarge'
+    assert r_c['ami_id'] == 'ami-03cca83dd001d4111'
 
 
 @patch('aws_xray_sdk.core.plugins.ec2_plugin.do_request')
@@ -48,4 +58,4 @@ def test_ec2_plugin_v2_fail_v1_fail(mock_do_request):
     ec2_plugin.initialize()
     assert hasattr(ec2_plugin, 'runtime_context')
     r_c = getattr(ec2_plugin, 'runtime_context')
-    assert r_c is None
+    assert r_c == {}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Using EC2 instance document to fetch metadata all at once instead of separate request to different endpoints. This provides extensibility to add more metadata to the plugin. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
