### PR TITLE
SqlAlchemy: Close segment even if error was raised

### DIFF
--- a/aws_xray_sdk/ext/sqlalchemy/util/decorators.py
+++ b/aws_xray_sdk/ext/sqlalchemy/util/decorators.py
@@ -58,11 +58,14 @@ def xray_on_call(cls, func):
                 subsegment = xray_recorder.begin_subsegment(sub_name, namespace='remote')
             else:
                 subsegment = None
-        res = func(*args, **kw)
-        if subsegment is not None:
-            subsegment.set_sql(sql)
-            subsegment.put_annotation("sqlalchemy", class_name+'.'+func.__name__)
-            xray_recorder.end_subsegment()
+
+        try:
+            res = func(*args, **kw)
+        finally:
+            if subsegment is not None:
+                subsegment.set_sql(sql)
+                subsegment.put_annotation("sqlalchemy", class_name+'.'+func.__name__)
+                xray_recorder.end_subsegment()
         return res
     return wrapper
 # URL Parse output


### PR DESCRIPTION
*Issue #, if available:*
If sqlalchemy raises an error, segment is not closed (have subsegments count > 0).
Minimal code to reproduce

```
from aws_xray_sdk.core import xray_recorder
from aws_xray_sdk.ext.flask_sqlalchemy.query import XRayFlaskSqlAlchemy
from flask import Flask


xray_recorder.configure(daemon_address='127.0.0.1:2000')

app = Flask(__name__)
db = XRayFlaskSqlAlchemy()
db.init_app(app)
db.app = app

class Test(db.Model):
    id = db.Column(db.String(30), primary_key=True)


with app.app_context():
    with xray_recorder.in_segment('segment_name') as segment:
        Test.query.all() # should raise Exception, and segment should be written to daemon

```

Expected behaviour: segment is written to xray daemon
Current behavioud: segment just silently skipped


*Description of changes:*
Run endsubsegment in case of error too.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
