### PR TITLE
Include unicode type for annotation values

### DIFF
--- a/aws_xray_sdk/core/utils/compat.py
+++ b/aws_xray_sdk/core/utils/compat.py
@@ -6,7 +6,7 @@ PY2 = sys.version_info < (3,)
 PY35 = sys.version_info >= (3, 5)
 
 if PY2:
-    annotation_value_types = (int, long, float, bool, str)  # noqa: F821
+    annotation_value_types = (int, long, float, bool, str, unicode)  # noqa: F821
     string_types = basestring  # noqa: F821
 else:
     annotation_value_types = (int, float, bool, str)


### PR DESCRIPTION
Description of changes:

The AWS X-Ray documentation says the annotation value can be a unicode type. (https://docs.aws.amazon.com/xray/latest/devguide/xray-sdk-python-segment.html#xray-sdk-python-segment-annotations) But aws-xray-sdk-python does not allow unicode type for annotation values in Python 2. I think this is a bug.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
