### PR TITLE
set pymysql version to 0.9.3 in case of 0.10 upgrade

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -26,7 +26,7 @@ deps =
     django30: Django==3.0.*
     django{111,22,30}: django-fake-model
     pynamodb >= 3.3.1
-    pymysql=0.9.3
+    pymysql==0.9.3
     psycopg2
     pg8000
     testing.postgresql

--- a/tox.ini
+++ b/tox.ini
@@ -26,7 +26,7 @@ deps =
     django30: Django==3.0.*
     django{111,22,30}: django-fake-model
     pynamodb >= 3.3.1
-    pymysql
+    pymysql=0.9.3
     psycopg2
     pg8000
     testing.postgresql


### PR DESCRIPTION
*Issue #, if available:*
PyMySQL upgrade from 0.9.3 to 0.10 on 18th July, the new version changes a lot includes some exception types changes which causes x-ray sdk unit test failed.
https://github.com/PyMySQL/PyMySQL/blob/master/CHANGELOG.md

*Description of changes:*
roll back PyMySQL version to 0.9.3.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
