### PR TITLE
Run tests against Django 3.1 instead of 1.11

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -2,9 +2,9 @@
 envlist =
     py{27,34,35,36,37,38}-default
     py{35,36,37,38}-aiohttp2
-    py{27,34,35,36,37}-django111
     py{35,36,37,38}-django22
     py{36,37,38}-django30
+    py{36,37,38}-django31
     coverage-report
 
 skip_missing_interpreters = True
@@ -21,10 +21,10 @@ deps =
     sqlalchemy
     Flask-SQLAlchemy
     future
-    django111: Django==1.11.*
     django22: Django==2.2.*
     django30: Django==3.0.*
-    django{111,22,30}: django-fake-model
+    django31: Django==3.1.*
+    django{22,30,31}: django-fake-model
     pynamodb >= 3.3.1
     pymysql
     psycopg2
@@ -45,7 +45,7 @@ deps =
 commands =
     py{27,34}-default: coverage run --source aws_xray_sdk -m py.test tests --ignore tests/ext/aiohttp --ignore tests/ext/aiobotocore --ignore tests/ext/django --ignore tests/test_async_local_storage.py --ignore tests/test_async_recorder.py
     py{35,36,37,38}-default: coverage run --source aws_xray_sdk -m py.test --ignore tests/ext/django tests
-    django{111,22,30}: coverage run --source aws_xray_sdk -m py.test tests/ext/django
+    django{22,30,31}: coverage run --source aws_xray_sdk -m py.test tests/ext/django
     codecov
 
 setenv =


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:* Ensure support for Django 3.1, ignore Django 1.11.

- Django 1.11 (LTS) reached its EOL on 2020-04-01.  The current LTS release is 2.2.
- Django 3.1 was released on 2020-08-04.

The list of supported version is available at https://www.djangoproject.com/download/.

~The test failures are unrelated, see aws/aws-xray-sdk-python#239.~ (rebased)

----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
