### PR TITLE
Restore python2 compatibility of EC2 plugin

### DIFF
--- a/aws_xray_sdk/core/plugins/ec2_plugin.py
+++ b/aws_xray_sdk/core/plugins/ec2_plugin.py
@@ -1,9 +1,9 @@
 import json
 import logging
 from future.standard_library import install_aliases
-from urllib.request import urlopen, Request
-
 install_aliases()
+
+from urllib.request import urlopen, Request
 
 log = logging.getLogger(__name__)
 


### PR DESCRIPTION
*Description of changes:*
In this [PR](https://github.com/aws/aws-xray-sdk-python/pull/226/files), python2 compatibility broke.

`from urllib.request import urlopen, Request` will not work unless `install_aliases()` is called before:
```
❯ python2
Python 2.7.18 (v2.7.18:8d21aa21f2, Apr 19 2020, 20:48:48)
[GCC 4.2.1 Compatible Apple LLVM 6.0 (clang-600.0.57)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>>
>>> import json
>>> import logging
>>> from future.standard_library import install_aliases
>>> from urllib.request import urlopen, Request
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ImportError: No module named request
>>> install_aliases()
>>> from urllib.request import urlopen, Request
>>>
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
