### PR TITLE
Allow configuring different Sampler in Django App

### DIFF
--- a/aws_xray_sdk/ext/django/apps.py
+++ b/aws_xray_sdk/ext/django/apps.py
@@ -30,6 +30,7 @@ class XRayConfig(AppConfig):
             daemon_address=settings.AWS_XRAY_DAEMON_ADDRESS,
             sampling=settings.SAMPLING,
             sampling_rules=settings.SAMPLING_RULES,
+            sampler=settings.SAMPLER,
             context_missing=settings.AWS_XRAY_CONTEXT_MISSING,
             plugins=settings.PLUGINS,
             service=settings.AWS_XRAY_TRACING_NAME,

--- a/aws_xray_sdk/ext/django/conf.py
+++ b/aws_xray_sdk/ext/django/conf.py
@@ -10,6 +10,7 @@ DEFAULTS = {
     'PLUGINS': (),
     'SAMPLING': True,
     'SAMPLING_RULES': None,
+    'SAMPLER': None,
     'AWS_XRAY_TRACING_NAME': None,
     'DYNAMIC_NAMING': None,
     'STREAMING_THRESHOLD': None,

--- a/tests/ext/django/app/settings.py
+++ b/tests/ext/django/app/settings.py
@@ -2,6 +2,7 @@
 Config file for a django app used by django testing client
 """
 import os
+from aws_xray_sdk.core.sampling.sampler import LocalSampler
 
 
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -60,6 +61,7 @@ INSTALLED_APPS = [
 XRAY_RECORDER = {
     'AWS_XRAY_TRACING_NAME': 'django',
     'SAMPLING': False,
+    'SAMPLER': LocalSampler(),
 }
 
 LANGUAGE_CODE = 'en-us'

--- a/tests/ext/django/test_settings.py
+++ b/tests/ext/django/test_settings.py
@@ -1,0 +1,16 @@
+from unittest import mock
+
+import django
+from aws_xray_sdk import global_sdk_config
+from django.test import TestCase, override_settings
+from django.conf import settings
+from django.apps import apps
+
+from aws_xray_sdk.core import xray_recorder
+from aws_xray_sdk.core.sampling.sampler import LocalSampler
+
+
+class XRayConfigurationTestCase(TestCase):
+    def test_sampler_can_be_configured(self):
+        assert isinstance(settings.XRAY_RECORDER['SAMPLER'], LocalSampler)
+        assert isinstance(xray_recorder.sampler, LocalSampler)


### PR DESCRIPTION
This patch adapts `aws_xray_sdk.ext.django` to be able to configure `Sampler` type.

Because right now it uses `aws_xray_sdk.core.sampling.sampler.DefaultSampler`, and doesn't allow configuring an alternative. Which means that it's impossible to use local sampling rules with Django


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
