### PR TITLE
Added `always()` to run clean up workflow

### DIFF
--- a/.github/workflows/IntegrationTesting.yaml
+++ b/.github/workflows/IntegrationTesting.yaml
@@ -140,7 +140,7 @@ jobs:
   cleanup:
     name: Resource tear down
     needs: test_WebApp
-    if: true
+    if: always()
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/IntegrationTesting.yaml
+++ b/.github/workflows/IntegrationTesting.yaml
@@ -163,7 +163,7 @@ jobs:
         run: terraform init
 
       - name: set permissions to terraform plugins
-        run: chmod -R a+x .terraform/plugins/registry.terraform.io/hashicorp/aws/3.5.0/linux_amd64/*
+        run: chmod -R a+x .terraform/plugins/registry.terraform.io/hashicorp/aws/*
 
       - name: Destroy resources
         run: terraform destroy -state="terraform.tfstate" -var-file="fixtures.us-west-2.tfvars" -auto-approve

--- a/.github/workflows/IntegrationTesting.yaml
+++ b/.github/workflows/IntegrationTesting.yaml
@@ -163,7 +163,7 @@ jobs:
         run: terraform init
 
       - name: set permissions to terraform plugins
-        run: chmod -R a+x .terraform/plugins/registry.terraform.io/hashicorp/aws/*
+        run: chmod -R a+x .terraform/*
 
       - name: Destroy resources
         run: terraform destroy -state="terraform.tfstate" -var-file="fixtures.us-west-2.tfvars" -auto-approve


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

cleanup job will run even in the event of test failures.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
