### PR TITLE
Add ability to ignore some requests from httplib

### DIFF
--- a/README.md
+++ b/README.md
@@ -476,7 +476,7 @@ db = XRayFlaskSqlAlchemy(app)
 
 ### Ignoring httplib requests
 
-If you want to ignore certain httplib requests you can do so based on the hostname or URL that is being requsted. 
+If you want to ignore certain httplib requests you can do so based on the hostname or URL that is being requsted. The hostname is matched using the Python [fnmatch library](https://docs.python.org/3/library/fnmatch.html) which does Unix glob style matching.
 
 ```python
 from aws_xray_sdk.ext.httplib import add_ignored as xray_add_ignored
@@ -492,6 +492,15 @@ xray_add_ignored(urls=['/test-path', '/other-test-path'])
 
 # ignore requests to myapp.com for /test-url
 xray_add_ignored(hostname='myapp.com', urls=['/test-url'])
+```
+
+If you use a subclass of httplib to make your requests, you can also filter on the class name that initiates the request. This must use the complete package name to do the match.
+
+```python
+from aws_xray_sdk.ext.httplib import add_ignored as xray_add_ignored
+
+# ignore all requests made by botocore
+xray_add_ignored(subclass='botocore.awsrequest.AWSHTTPConnection')
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -473,6 +473,27 @@ XRayMiddleware(app, xray_recorder)
 db = XRayFlaskSqlAlchemy(app)
 
 ```
+
+### Ignoring httplib requests
+
+If you want to ignore certain httplib requests you can do so based on the hostname or URL that is being requsted. 
+
+```python
+from aws_xray_sdk.ext.httplib import add_ignored as xray_add_ignored
+
+# ignore requests to test.myapp.com
+xray_add_ignored(hostname='test.myapp.com')
+
+# ignore requests to a subdomain of myapp.com with a glob pattern
+xray_add_ignored(hostname='*.myapp.com')
+
+# ignore requests to /test-url and /other-test-url
+xray_add_ignored(urls=['/test-path', '/other-test-path'])
+
+# ignore requests to myapp.com for /test-url
+xray_add_ignored(hostname='myapp.com', urls=['/test-url'])
+```
+
 ## License
 
 The AWS X-Ray SDK for Python is licensed under the Apache 2.0 License. See LICENSE and NOTICE.txt for more information.

--- a/aws_xray_sdk/ext/httplib/__init__.py
+++ b/aws_xray_sdk/ext/httplib/__init__.py
@@ -1,3 +1,3 @@
-from .patch import patch, unpatch
+from .patch import patch, unpatch, add_ignored, reset_ignored
 
-__all__ = ['patch', 'unpatch']
+__all__ = ['patch', 'unpatch', 'add_ignored', 'reset_ignored']

--- a/aws_xray_sdk/ext/httplib/patch.py
+++ b/aws_xray_sdk/ext/httplib/patch.py
@@ -22,8 +22,33 @@ else:
 
 _XRAY_PROP = '_xray_prop'
 _XRay_Data = namedtuple('xray_data', ['method', 'host', 'url'])
+_XRay_Ignore = namedtuple('xray_ignore', ['subclass', 'hostname', 'urls'])
 # A flag indicates whether this module is X-Ray patched or not
 PATCH_FLAG = '__xray_patched'
+# Calls that should be ignored
+_XRAY_IGNORE = set()
+
+
+def add_ignored(subclass=None, hostname=None, urls=None):
+    global _XRAY_IGNORE
+    if subclass is not None or hostname is not None or urls is not None:
+        urls = urls if urls is None else tuple(urls)
+        _XRAY_IGNORE.add(_XRay_Ignore(subclass=subclass, hostname=hostname, urls=urls))
+
+
+def reset_ignored():
+    global _XRAY_IGNORE
+    _XRAY_IGNORE.clear()
+    _ignored_add_default()
+
+
+def _ignored_add_default():
+    # skip httplib tracing for SDK built-in centralized sampling pollers
+    add_ignored(subclass='botocore.awsrequest.AWSHTTPConnection', urls=['/GetSamplingRules', '/SamplingTargets'])
+
+
+# make sure we have the default rules
+_ignored_add_default()
 
 
 def http_response_processor(wrapped, instance, args, kwargs, return_value,
@@ -77,11 +102,21 @@ def http_send_request_processor(wrapped, instance, args, kwargs, return_value,
         subsegment.add_exception(exception, stack)
 
 
+def _ignore_request(subclass, hostname, url):
+    global _XRAY_IGNORE
+    for rule in _XRAY_IGNORE:
+        subclass_match = subclass == rule.subclass if rule.subclass is not None else True
+        host_match = hostname == rule.hostname if rule.hostname is not None else True
+        url_match = url in rule.urls if rule.urls is not None else True
+        if url_match and host_match and subclass_match:
+            return True
+    return False
+
+
 def _send_request(wrapped, instance, args, kwargs):
     def decompose_args(method, url, body, headers, encode_chunked=False):
-        # skip httplib tracing for SDK built-in centralized sampling pollers
-        if (('/GetSamplingRules' in args or '/SamplingTargets' in args) and
-                type(instance).__name__ == 'botocore.awsrequest.AWSHTTPConnection'):
+        # skip any ignored requests
+        if _ignore_request(type(instance).__name__, instance.host, url):
             return wrapped(*args, **kwargs)
 
         # Only injects headers when the subsegment for the outgoing

--- a/aws_xray_sdk/ext/httplib/patch.py
+++ b/aws_xray_sdk/ext/httplib/patch.py
@@ -1,7 +1,7 @@
 from collections import namedtuple
 import sys
 import wrapt
-
+import fnmatch
 import urllib3.connection
 
 from aws_xray_sdk.core import xray_recorder
@@ -106,7 +106,7 @@ def _ignore_request(subclass, hostname, url):
     global _XRAY_IGNORE
     for rule in _XRAY_IGNORE:
         subclass_match = subclass == rule.subclass if rule.subclass is not None else True
-        host_match = hostname == rule.hostname if rule.hostname is not None else True
+        host_match = fnmatch.fnmatch(hostname, rule.hostname) if rule.hostname is not None else True
         url_match = url in rule.urls if rule.urls is not None else True
         if url_match and host_match and subclass_match:
             return True

--- a/tests/ext/httplib/test_httplib.py
+++ b/tests/ext/httplib/test_httplib.py
@@ -171,15 +171,16 @@ def test_ignore_hostname_glob():
     assert len(xray_recorder.current_segment().subsegments) == 0
 
 
-class TestClass(httplib.HTTPSConnection):
+class CustomHttpsConnection(httplib.HTTPSConnection):
     pass
 
 
 def test_ignore_subclass():
     from aws_xray_sdk.ext.httplib import add_ignored
     path = '/status/200'
-    add_ignored(subclass='TestClass')
-    conn = TestClass(BASE_URL)
+    subclass = 'tests.ext.httplib.test_httplib.CustomHttpsConnection'
+    add_ignored(subclass=subclass)
+    conn = CustomHttpsConnection(BASE_URL)
     conn.request('GET', path)
     conn.getresponse()
     assert len(xray_recorder.current_segment().subsegments) == 0
@@ -188,8 +189,9 @@ def test_ignore_subclass():
 def test_ignore_multiple_match():
     from aws_xray_sdk.ext.httplib import add_ignored
     path = '/status/200'
-    add_ignored(subclass='TestClass', hostname=BASE_URL)
-    conn = TestClass(BASE_URL)
+    subclass = 'tests.ext.httplib.test_httplib.CustomHttpsConnection'
+    add_ignored(subclass=subclass, hostname=BASE_URL)
+    conn = CustomHttpsConnection(BASE_URL)
     conn.request('GET', path)
     conn.getresponse()
     assert len(xray_recorder.current_segment().subsegments) == 0
@@ -198,8 +200,9 @@ def test_ignore_multiple_match():
 def test_ignore_multiple_no_match():
     from aws_xray_sdk.ext.httplib import add_ignored
     path = '/status/200'
-    add_ignored(subclass='TestClass', hostname='fake.host')
-    conn = TestClass(BASE_URL)
+    subclass = 'tests.ext.httplib.test_httplib.CustomHttpsConnection'
+    add_ignored(subclass=subclass, hostname='fake.host')
+    conn = CustomHttpsConnection(BASE_URL)
     conn.request('GET', path)
     conn.getresponse()
     assert len(xray_recorder.current_segment().subsegments) > 0

--- a/tests/ext/httplib/test_httplib.py
+++ b/tests/ext/httplib/test_httplib.py
@@ -163,6 +163,16 @@ def test_ignore_hostname():
     reset_ignored()
 
 
+def test_ignore_hostname_glob():
+    from aws_xray_sdk.ext.httplib import add_ignored, reset_ignored
+    path = '/status/200'
+    url = 'https://{}{}'.format(BASE_URL, path)
+    add_ignored(hostname='http*.org')
+    _do_req(url, use_https=True)
+    assert len(xray_recorder.current_segment().subsegments) == 0
+    reset_ignored()
+
+
 def test_ignore_subclass():
     class TestClass(httplib.HTTPSConnection):
         pass


### PR DESCRIPTION
*Description of changes:*
This generalizes the test that the httplib patch was doing to ignore requests to xray being made by botocore. I am using cloudwatch logging in my application, and these calls occur outside of the normal application flow, so I don't have a segment open for them. 

This adds a new function `add_ignored` that allows requests to be ignored based on the `hostname`, `url` or `subclass`.  It defaults to ignoring the same things as before, but now additional requests can be ignored.

I also added some tests for the new functionality.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
