### PR TITLE
Update docs with supported libraries

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -22,11 +22,16 @@ Currently supported web frameworks and libraries:
 * aioboto3/aiobotocore
 * aiohttp >=2.3
 * boto3/botocore
+* Bottle
 * Django >=1.10
 * Flask
-* httplib
+* httplib/http.client
 * mysql-connector
-* Pynamodb
+* pg8000
+* psycopg2
+* pymongo
+* pymysql
+* pynamodb
 * requests
 * SQLAlchemy
 * sqlite3

--- a/tox.ini
+++ b/tox.ini
@@ -26,7 +26,6 @@ deps =
     django31: Django==3.1.*
     django{22,30,31}: django-fake-model
     pynamodb >= 3.3.1
-    pymysql
     psycopg2
     pg8000
     testing.postgresql
@@ -36,11 +35,13 @@ deps =
 
     # Python2 only deps
     py{27}: enum34
+    py{27}: pymysql < 1.0.0
 
     # Python3.5+ only deps
     py{35,36,37,38}: aiohttp >= 3.0.0
     py{35,36,37,38}: pytest-aiohttp
     py{35,36,37,38}: aiobotocore >= 0.10.0
+    py{35,36,37,38}: pymysql >= 1.0.0
 
 commands =
     py{27,34}-default: coverage run --source aws_xray_sdk -m py.test tests --ignore tests/ext/aiohttp --ignore tests/ext/aiobotocore --ignore tests/ext/django --ignore tests/test_async_local_storage.py --ignore tests/test_async_recorder.py

--- a/tox.ini
+++ b/tox.ini
@@ -36,14 +36,14 @@ deps =
     # Python2 only deps
     py{27}: enum34
     
-    # pymysql deps for py 2.7 and 3.4
-    py{27,34}: pymysql < 1.0.0
+    # pymysql deps
+    py{27,34,35}: pymysql < 1.0.0
+    py{36,37,38}: pymysql >= 1.0.0
 
     # Python3.5+ only deps
     py{35,36,37,38}: aiohttp >= 3.0.0
     py{35,36,37,38}: pytest-aiohttp
     py{35,36,37,38}: aiobotocore >= 0.10.0
-    py{35,36,37,38}: pymysql >= 1.0.0
 
 commands =
     py{27,34}-default: coverage run --source aws_xray_sdk -m py.test tests --ignore tests/ext/aiohttp --ignore tests/ext/aiobotocore --ignore tests/ext/django --ignore tests/test_async_local_storage.py --ignore tests/test_async_recorder.py

--- a/tox.ini
+++ b/tox.ini
@@ -35,7 +35,9 @@ deps =
 
     # Python2 only deps
     py{27}: enum34
-    py{27}: pymysql < 1.0.0
+    
+    # pymysql deps for py 2.7 and 3.4
+    py{27,34}: pymysql < 1.0.0
 
     # Python3.5+ only deps
     py{35,36,37,38}: aiohttp >= 3.0.0


### PR DESCRIPTION
*Issue #, if available:* #225

The [aws docs](https://docs.aws.amazon.com/xray/latest/devguide/xray-sdk-python-patching.html) seems to be updated with the current set of frameworks and libraries. Updating the [developer docs](https://docs.aws.amazon.com/xray-sdk-for-python/latest/reference/) as well to keep consistency.
Also updating tox.ini to use correct pymysql version since they dropped support for python 3.5 and below in v1.0.0.
 
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
