### PR TITLE
Handling condition where Entity.cause is not a dict.

### DIFF
--- a/aws_xray_sdk/core/models/entity.py
+++ b/aws_xray_sdk/core/models/entity.py
@@ -211,7 +211,7 @@ class Entity(object):
         """
         Add an exception to trace entities.
 
-        :param Exception exception: the catched exception.
+        :param Exception exception: the caught exception.
         :param list stack: the output from python built-in
             `traceback.extract_stack()`.
         :param bool remote: If False it means it's a client error
@@ -224,7 +224,16 @@ class Entity(object):
             setattr(self, 'cause', getattr(exception, '_cause_id'))
             return
 
-        exceptions = []
+        if not isinstance(self.cause, dict):
+            log.warning("The current cause object is not a dict but an id: {}. Resetting the cause and recording the "
+                        "current exception".format(self.cause))
+            self.cause = {}
+
+        if 'exceptions' in self.cause:
+            exceptions = self.cause['exceptions']
+        else:
+            exceptions = []
+
         exceptions.append(Throwable(exception, stack, remote))
 
         self.cause['exceptions'] = exceptions

--- a/tests/test_trace_entities.py
+++ b/tests/test_trace_entities.py
@@ -1,4 +1,6 @@
 # -*- coding: iso-8859-15 -*-
+from __future__ import unicode_literals
+
 import pytest
 
 from aws_xray_sdk.core.models.segment import Segment

--- a/tests/test_trace_entities.py
+++ b/tests/test_trace_entities.py
@@ -1,7 +1,7 @@
 # -*- coding: iso-8859-15 -*-
-from __future__ import unicode_literals
 
 import pytest
+import sys
 
 from aws_xray_sdk.core.models.segment import Segment
 from aws_xray_sdk.core.models.subsegment import Subsegment
@@ -230,7 +230,10 @@ def test_add_exception_referencing():
     subseg_cause = subseg.cause
 
     assert isinstance(subseg_cause, dict)
-    assert isinstance(seg_cause, str)
+    if sys.version_info.major == 2:
+        assert isinstance(seg_cause, basestring)
+    else:
+        assert isinstance(seg_cause, str)
     assert seg_cause == subseg_cause['exceptions'][0].id
 
 

--- a/tests/test_trace_entities.py
+++ b/tests/test_trace_entities.py
@@ -216,7 +216,7 @@ def test_add_exception():
 
 def test_add_exception_referencing():
     segment = Segment('seg')
-    subseg = Subsegment('subseg')
+    subseg = Subsegment('subseg', 'remote', segment)
     exception = Exception("testException")
     stack = [['path', 'line', 'label']]
     subseg.add_exception(exception=exception, stack=stack)
@@ -234,25 +234,26 @@ def test_add_exception_referencing():
 
 def test_add_exception_cause_resetting():
     segment = Segment('seg')
-    subseg = Subsegment('subseg')
+    subseg = Subsegment('subseg', 'remote', segment)
     exception = Exception("testException")
     stack = [['path', 'line', 'label']]
     subseg.add_exception(exception=exception, stack=stack)
     segment.add_exception(exception=exception, stack=stack)
 
-    segment.add_exception(exception=Exception("newException"))
+    segment.add_exception(exception=Exception("newException"), stack=stack)
     subseg.close()
     segment.close()
 
     seg_cause = segment.cause
     assert isinstance(seg_cause, dict)
-    assert 'newException' == seg_cause['exceptons'][0].message
+    assert 'newException' == seg_cause['exceptions'][0].message
 
 
 def test_add_exception_appending_exceptions():
     segment = Segment('seg')
-    segment.add_exception(exception=Exception("testException"))
-    segment.add_exception(exception=Exception("newException"))
+    stack = [['path', 'line', 'label']]
+    segment.add_exception(exception=Exception("testException"), stack=stack)
+    segment.add_exception(exception=Exception("newException"), stack=stack)
     segment.close()
 
     assert isinstance(segment.cause, dict)


### PR DESCRIPTION
*Issue* #154 

*Description of changes:*
In a case of exception chaining where an unhandled exception is captured in a subsegment and then propagated to the parent segment/subsegment, the `cause` property of this parent entity becomes a `str` from `dict` to record the exception id from the child subsegment. Any further dictionary operation this `cause` will result in TypeError.
Doing a type check on the Entity.cause when adding a new exception and resetting the cause to dict since we cannot recover the original cause dict once it has been updated to a string.

Also, making sure when adding multiple exceptions to an entity, they should be appended and not replaced.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
