### PR TITLE
Close segment in only `_handle_exception` in case of Internal Server Error

### DIFF
--- a/aws_xray_sdk/ext/flask/middleware.py
+++ b/aws_xray_sdk/ext/flask/middleware.py
@@ -81,6 +81,9 @@ class XRayMiddleware(object):
         if cont_len:
             segment.put_http_meta(http.CONTENT_LENGTH, int(cont_len))
 
+        if response.status_code >= 500:
+            return response
+
         if self.in_lambda_ctx:
             self._recorder.end_subsegment()
         else:

--- a/tests/ext/flask/test_flask.py
+++ b/tests/ext/flask/test_flask.py
@@ -39,8 +39,11 @@ recorder = get_new_stubbed_recorder()
 recorder.configure(service='test', sampling=False, context=Context())
 XRayMiddleware(app, recorder)
 
-# enable testing mode
-app.config['TESTING'] = True
+# We don't need to enable testing mode by doing app.config['TESTING'] = True
+# because what it does is disable error catching during request handling,
+# so that you get better error reports when performing test requests against the application.
+# But this also results in `after_request` method not getting invoked during unhandled exception which we want
+# since it is the actual application behavior in our use case.
 app = app.test_client()
 
 BASE_URL = 'http://localhost{}'


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws/aws-xray-sdk-python/issues/269

*Description of changes:*
- Return from `_after_request` when response code >= 500 so that the exception in recorded on the segment in the `_handle_exception` method.
-  Not enabling the testing mode so that the request is handled by the application in usual way during the exception

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
