### PR TITLE
BugFix: Always close segment in teardown_request handler 

### DIFF
--- a/aws_xray_sdk/ext/flask/middleware.py
+++ b/aws_xray_sdk/ext/flask/middleware.py
@@ -91,8 +91,6 @@ class XRayMiddleware(object):
         return response
 
     def _handle_exception(self, exception):
-        if not exception:
-            return
         segment = None
         try:
             if self.in_lambda_ctx:
@@ -104,9 +102,11 @@ class XRayMiddleware(object):
         if not segment:
             return
 
-        segment.put_http_meta(http.STATUS, 500)
-        stack = stacktrace.get_stacktrace(limit=self._recorder._max_trace_back)
-        segment.add_exception(exception, stack)
+        if exception:
+            segment.put_http_meta(http.STATUS, 500)
+            stack = stacktrace.get_stacktrace(limit=self._recorder._max_trace_back)
+            segment.add_exception(exception, stack)
+
         if self.in_lambda_ctx:
             self._recorder.end_subsegment()
         else:


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws/aws-xray-sdk-python/issues/269

*Description of changes:*
The previous PR which intended to fix the #269 introduced a [bug](https://github.com/aws/aws-xray-sdk-python/pull/271#issuecomment-772741466) where if the flask application does not pass an exception in case of response code >= 500, the segment will remain unclosed. This may be an edge case scenario that application faults do not pass exception to `teardown_request` handler but it is still a [valid case of responses](https://flask.palletsprojects.com/en/1.1.x/quickstart/#about-responses).
Thus, irrespective of exception being present or not, the middleware should always end the segment if its present. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
