### PR TITLE
Fixed serialization issue when cause is a string

### DIFF
--- a/aws_xray_sdk/core/models/entity.py
+++ b/aws_xray_sdk/core/models/entity.py
@@ -280,13 +280,16 @@ class Entity(object):
                         subsegments.append(subsegment.to_dict())
                     entity_dict[key] = subsegments
                 elif key == 'cause':
-                    entity_dict[key] = {}
-                    entity_dict[key]['working_directory'] = self.cause['working_directory']
-                    # exceptions are stored as List
-                    throwables = []
-                    for throwable in value['exceptions']:
-                        throwables.append(throwable.to_dict())
-                    entity_dict[key]['exceptions'] = throwables
+                    if isinstance(self.cause, dict):
+                        entity_dict[key] = {}
+                        entity_dict[key]['working_directory'] = self.cause['working_directory']
+                        # exceptions are stored as List
+                        throwables = []
+                        for throwable in value['exceptions']:
+                            throwables.append(throwable.to_dict())
+                        entity_dict[key]['exceptions'] = throwables
+                    else:
+                        entity_dict[key] = self.cause
                 elif key == 'metadata':
                     entity_dict[key] = metadata_to_dict(value)
                 elif key != 'sampled' and key != ORIGIN_TRACE_HEADER_ATTR_KEY:


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-xray-sdk-python/issues/283
*Description of changes:*
Fixed serialization issue when `cause` is a `str`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
