### PR TITLE
Run tests against Python 3.9 and Django 3.2 LTS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ python:
   - "3.6"
   - "3.7"
   - "3.8"
+  - "3.9"
 
 install:
   - pip install tox tox-travis

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 ## Installing
 
-The AWS X-Ray SDK for Python is compatible with Python 2.7, 3.4, 3.5, 3.6, 3.7, and 3.8.
+The AWS X-Ray SDK for Python is compatible with Python 2.7, 3.4, 3.5, 3.6, 3.7, 3.8, and 3.9.
 
 Install the SDK using the following command (the SDK's non-testing dependencies will be installed).
 

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,7 @@ setup(
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
     ],
 
     install_requires=[

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,10 @@
 [tox]
 envlist =
-    py{27,34,35,36,37,38}-default
-    py{35,36,37,38}-aiohttp2
-    py{35,36,37,38}-django22
-    py{36,37,38}-django30
-    py{36,37,38}-django31
+    py{27,34,35,36,37,38,39}-default
+    py{35,36,37,38,39}-aiohttp2
+    py{35,36,37,38,39}-django22
+    py{36,37,38,39}-django30
+    py{36,37,38,39}-django31
     coverage-report
 
 skip_missing_interpreters = True
@@ -35,19 +35,19 @@ deps =
 
     # Python2 only deps
     py{27}: enum34
-    
+
     # pymysql deps
     py{27,34,35}: pymysql < 1.0.0
-    py{36,37,38}: pymysql >= 1.0.0
+    py{36,37,38,39}: pymysql >= 1.0.0
 
     # Python3.5+ only deps
-    py{35,36,37,38}: aiohttp >= 3.0.0
-    py{35,36,37,38}: pytest-aiohttp
-    py{35,36,37,38}: aiobotocore >= 0.10.0
+    py{35,36,37,38,39}: aiohttp >= 3.0.0
+    py{35,36,37,38,39}: pytest-aiohttp
+    py{35,36,37,38,39}: aiobotocore >= 0.10.0
 
 commands =
     py{27,34}-default: coverage run --source aws_xray_sdk -m py.test tests --ignore tests/ext/aiohttp --ignore tests/ext/aiobotocore --ignore tests/ext/django --ignore tests/test_async_local_storage.py --ignore tests/test_async_recorder.py
-    py{35,36,37,38}-default: coverage run --source aws_xray_sdk -m py.test --ignore tests/ext/django tests
+    py{35,36,37,38,39}-default: coverage run --source aws_xray_sdk -m py.test --ignore tests/ext/django tests
     django{22,30,31}: coverage run --source aws_xray_sdk -m py.test tests/ext/django
     codecov
 

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,7 @@ envlist =
     py{35,36,37,38,39}-django22
     py{36,37,38,39}-django30
     py{36,37,38,39}-django31
+    py{36,37,38,39}-django32
     coverage-report
 
 skip_missing_interpreters = True
@@ -24,7 +25,8 @@ deps =
     django22: Django==2.2.*
     django30: Django==3.0.*
     django31: Django==3.1.*
-    django{22,30,31}: django-fake-model
+    django32: Django==3.2.*
+    django{22,30,31,32}: django-fake-model
     pynamodb >= 3.3.1
     psycopg2
     pg8000
@@ -48,7 +50,7 @@ deps =
 commands =
     py{27,34}-default: coverage run --source aws_xray_sdk -m py.test tests --ignore tests/ext/aiohttp --ignore tests/ext/aiobotocore --ignore tests/ext/django --ignore tests/test_async_local_storage.py --ignore tests/test_async_recorder.py
     py{35,36,37,38,39}-default: coverage run --source aws_xray_sdk -m py.test --ignore tests/ext/django tests
-    django{22,30,31}: coverage run --source aws_xray_sdk -m py.test tests/ext/django
+    django{22,30,31,32}: coverage run --source aws_xray_sdk -m py.test tests/ext/django
     codecov
 
 setenv =

--- a/tox.ini
+++ b/tox.ini
@@ -42,6 +42,9 @@ deps =
     py{27,34,35}: pymysql < 1.0.0
     py{36,37,38,39}: pymysql >= 1.0.0
 
+    # Python3.4 only deps
+    py34: typing >= 3.7.4.3
+
     # Python3.5+ only deps
     py{35,36,37,38,39}: aiohttp >= 3.0.0
     py{35,36,37,38,39}: pytest-aiohttp


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:*

- Run tests against Python 3.9 and Django 3.2 (the latest LTS release)
- Fix tests on Python 3.4


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
