### PR TITLE
Handle exception when sending entity to Daemon

### DIFF
--- a/aws_xray_sdk/core/emitters/udp_emitter.py
+++ b/aws_xray_sdk/core/emitters/udp_emitter.py
@@ -60,12 +60,7 @@ class UDPEmitter(object):
         return self._port
 
     def _send_data(self, data):
-
-        try:
-            self._socket.sendto(data.encode('utf-8'), (self._ip,
-                                self._port))
-        except Exception:
-            raise
+        self._socket.sendto(data.encode('utf-8'), (self._ip, self._port))
 
     def _parse_address(self, daemon_address):
         try:

--- a/aws_xray_sdk/core/emitters/udp_emitter.py
+++ b/aws_xray_sdk/core/emitters/udp_emitter.py
@@ -32,12 +32,15 @@ class UDPEmitter(object):
 
         :param entity: a trace entity to send to the X-Ray daemon
         """
-        message = "%s%s%s" % (PROTOCOL_HEADER,
-                              PROTOCOL_DELIMITER,
-                              entity.serialize())
+        try:
+            message = "%s%s%s" % (PROTOCOL_HEADER,
+                                  PROTOCOL_DELIMITER,
+                                  entity.serialize())
 
-        log.debug("sending: %s to %s:%s." % (message, self._ip, self._port))
-        self._send_data(message)
+            log.debug("sending: %s to %s:%s." % (message, self._ip, self._port))
+            self._send_data(message)
+        except Exception:
+            log.exception("Failed to send entity to Daemon")
 
     def set_daemon_address(self, address):
         """
@@ -62,7 +65,7 @@ class UDPEmitter(object):
             self._socket.sendto(data.encode('utf-8'), (self._ip,
                                 self._port))
         except Exception:
-            log.exception('failed to send data to X-Ray daemon.')
+            raise
 
     def _parse_address(self, daemon_address):
         try:

--- a/aws_xray_sdk/core/emitters/udp_emitter.py
+++ b/aws_xray_sdk/core/emitters/udp_emitter.py
@@ -40,7 +40,7 @@ class UDPEmitter(object):
             log.debug("sending: %s to %s:%s." % (message, self._ip, self._port))
             self._send_data(message)
         except Exception:
-            log.exception("Failed to send entity to Daemon")
+            log.exception("Failed to send entity to Daemon.")
 
     def set_daemon_address(self, address):
         """

--- a/aws_xray_sdk/core/models/entity.py
+++ b/aws_xray_sdk/core/models/entity.py
@@ -259,10 +259,7 @@ class Entity(object):
         Serialize to JSON document that can be accepted by the
         X-Ray backend service. It uses json to perform serialization.
         """
-        try:
-            return json.dumps(self.to_dict(), default=str)
-        except Exception:
-            raise
+        return json.dumps(self.to_dict(), default=str)
 
     def to_dict(self):
         """

--- a/aws_xray_sdk/core/models/entity.py
+++ b/aws_xray_sdk/core/models/entity.py
@@ -262,7 +262,7 @@ class Entity(object):
         try:
             return json.dumps(self.to_dict(), default=str)
         except Exception:
-            log.exception("Failed to serialize %s", self.name)
+            raise
 
     def to_dict(self):
         """


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/aws/aws-xray-sdk-python/issues/288

*Description of changes:*

- Discard sending entity to Daemon if any exception happens during serialization

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
