### PR TITLE
Adding doc description to EC2 plugin

### DIFF
--- a/aws_xray_sdk/core/plugins/ec2_plugin.py
+++ b/aws_xray_sdk/core/plugins/ec2_plugin.py
@@ -28,6 +28,10 @@ def initialize():
 
 
 def get_token():
+    """
+    Get the session token for IMDSv2 endpoint valid for 60 seconds
+    by specifying the X-aws-ec2-metadata-token-ttl-seconds header.
+    """
     token = None
     try:
         headers = {"X-aws-ec2-metadata-token-ttl-seconds": "60"}


### PR DESCRIPTION
Adding description about IMDSv2 session token timeout header so that we have the `X-aws-ec2-metadata-token-ttl-seconds` in the generated documentations.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
