### PR TITLE
Replace slow json filename resolver

### DIFF
--- a/aws_xray_sdk/core/sampling/local/sampler.py
+++ b/aws_xray_sdk/core/sampling/local/sampler.py
@@ -1,13 +1,11 @@
 import json
+import pkgutil
 from random import Random
 
-from pkg_resources import resource_filename
 from .sampling_rule import SamplingRule
 from ...exceptions.exceptions import InvalidSamplingManifestError
 
-
-with open(resource_filename(__name__, 'sampling_rule.json')) as f:
-    local_sampling_rule = json.load(f)
+local_sampling_rule = json.loads(pkgutil.get_data(__name__, 'sampling_rule.json'))
 
 SUPPORTED_RULE_VERSION = (1, 2)
 

--- a/aws_xray_sdk/ext/boto_utils.py
+++ b/aws_xray_sdk/ext/boto_utils.py
@@ -1,8 +1,8 @@
 from __future__ import absolute_import
 # Need absolute import as botocore is also in the current folder for py27
 import json
+import pkgutil
 
-from pkg_resources import resource_filename
 from botocore.exceptions import ClientError
 
 from aws_xray_sdk.core import xray_recorder
@@ -12,8 +12,7 @@ from aws_xray_sdk.core.exceptions.exceptions import SegmentNotFoundException
 from aws_xray_sdk.ext.util import inject_trace_header, to_snake_case
 
 
-with open(resource_filename(__name__, 'resources/aws_para_whitelist.json'), 'r') as data_file:
-    whitelist = json.load(data_file)
+whitelist = json.loads(pkgutil.get_data(__name__, 'resources/aws_para_whitelist.json'))
 
 
 def inject_header(wrapped, instance, args, kwargs):

--- a/tests/mock_sampling_rule.json
+++ b/tests/mock_sampling_rule.json
@@ -1,0 +1,9 @@
+{
+    "version": 2,
+    "default": {
+      "fixed_target": 1,
+      "rate": 0.05
+    },
+    "rules": [
+    ]
+  }

--- a/tests/test_local_sampling_benchmark.py
+++ b/tests/test_local_sampling_benchmark.py
@@ -1,0 +1,16 @@
+import json
+import pkgutil
+from pkg_resources import resource_filename
+
+from aws_xray_sdk.core.sampling.local.sampler import LocalSampler
+
+def test_pkg_resources_static_read(benchmark):
+    def get_sampling_rule():
+        with open(resource_filename(__name__, 'mock_sampling_rule.json')) as f:
+            return json.load(f)
+    benchmark(get_sampling_rule)
+
+def test_pkgutil_static_read(benchmark):
+    def get_sampling_rule():
+        json.loads(pkgutil.get_data(__name__, 'mock_sampling_rule.json'))
+    benchmark(get_sampling_rule)

--- a/tests/test_local_sampling_benchmark.py
+++ b/tests/test_local_sampling_benchmark.py
@@ -2,15 +2,15 @@ import json
 import pkgutil
 from pkg_resources import resource_filename
 
-from aws_xray_sdk.core.sampling.local.sampler import LocalSampler
+# Faster
+def test_pkgutil_static_read(benchmark):
+    def get_sampling_rule():
+        return json.loads(pkgutil.get_data(__name__, 'mock_sampling_rule.json'))
+    benchmark(get_sampling_rule)
 
+# Slower
 def test_pkg_resources_static_read(benchmark):
     def get_sampling_rule():
         with open(resource_filename(__name__, 'mock_sampling_rule.json')) as f:
             return json.load(f)
-    benchmark(get_sampling_rule)
-
-def test_pkgutil_static_read(benchmark):
-    def get_sampling_rule():
-        json.loads(pkgutil.get_data(__name__, 'mock_sampling_rule.json'))
     benchmark(get_sampling_rule)

--- a/tox.ini
+++ b/tox.ini
@@ -16,6 +16,7 @@ skip_missing_interpreters = True
 passenv = TOXENV CI TRAVIS TRAVIS_* CODECOV_*
 deps =
     pytest > 3.0.0
+    pytest-benchmark
     coverage==4.5.4
     codecov
     requests


### PR DESCRIPTION
*Issue #305* 

*Description of changes:*

For optimization purposes, we found that `pkgutil.get_data(package, resource)` method could be used to read a file in a much faster way than `from pkg_resources import resource_filename`.

Learn more about [reading static files in Python](https://stackoverflow.com/questions/6028000/how-to-read-a-static-file-from-inside-a-python-package#comment108239645_58941536).

*How did I test*

I used `pytest-benchmark` to compare the performance of the two:

```
$ pytest test_local_sampling_benchmark.py
======================================================================================== test session starts =========================================================================================
platform darwin -- Python 3.9.5, pytest-6.2.4, py-1.10.0, pluggy-0.13.1
benchmark: 3.4.1 (defaults: timer=time.perf_counter disable_gc=False min_rounds=5 min_time=0.000005 max_time=1.0 calibration_precision=10 warmup=False warmup_iterations=100000)
rootdir: /Users/enowell/git/aws-xray-sdk-python
plugins: benchmark-3.4.1
collected 2 items

test_local_sampling_benchmark.py ..                                                                                                                                                            [100%]


---------------------------------------------------------------------------------------------- benchmark: 2 tests ---------------------------------------------------------------------------------------------
Name (time in us)                      Min                    Max                Mean              StdDev             Median                IQR            Outliers  OPS (Kops/s)            Rounds  Iterations
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_pkgutil_static_read           50.6210 (1.0)         828.0920 (1.0)       61.8523 (1.0)       22.4959 (1.0)      54.3770 (1.0)      10.4147 (1.0)       798;992       16.1676 (1.0)       11205           1
test_pkg_resources_static_read     64.9590 (1.28)     18,941.0130 (22.87)    100.6223 (1.63)     558.5882 (24.83)    79.4150 (1.46)     12.1315 (1.16)        2;111        9.9382 (0.61)       1144           1
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

Legend:
  Outliers: 1 Standard Deviation from Mean; 1.5 IQR (InterQuartile Range) from 1st Quartile and 3rd Quartile.
  OPS: Operations Per Second, computed as 1 / Mean
========================================================================================= 2 passed in 2.38s ==========================================================================================
```

which shows that `pkgutil` is faster.

*Noteworthy points*

* `pkgutil` is standard in `python2` as well, so it should work fine with it.
* I had a chance to do an e2e test and traces still make it to AWS X-Ray

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
