### PR TITLE
Drop PyPI mock package dependency on Python 3.3+

### DIFF
--- a/tests/ext/aiohttp/test_middleware.py
+++ b/tests/ext/aiohttp/test_middleware.py
@@ -5,7 +5,10 @@ Expects pytest-aiohttp
 """
 import asyncio
 from aws_xray_sdk import global_sdk_config
-from unittest.mock import patch
+try:
+    from unittest.mock import patch
+except ImportError:
+    from mock import patch  # Python 2
 
 from aiohttp import web
 from aiohttp.web_exceptions import HTTPUnauthorized

--- a/tests/ext/aiohttp/test_middleware.py
+++ b/tests/ext/aiohttp/test_middleware.py
@@ -8,7 +8,8 @@ from aws_xray_sdk import global_sdk_config
 try:
     from unittest.mock import patch
 except ImportError:
-    from mock import patch  # Python 2
+    # NOTE: Python 2 dependency
+    from mock import patch
 
 from aiohttp import web
 from aiohttp.web_exceptions import HTTPUnauthorized

--- a/tests/ext/django/test_settings.py
+++ b/tests/ext/django/test_settings.py
@@ -1,7 +1,8 @@
 try:
     from unittest import mock
 except ImportError:
-    import mock  # Python 2
+    # NOTE: Python 2 dependency
+    import mock
 
 import django
 from aws_xray_sdk import global_sdk_config

--- a/tests/ext/django/test_settings.py
+++ b/tests/ext/django/test_settings.py
@@ -1,4 +1,7 @@
-from unittest import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock  # Python 2
 
 import django
 from aws_xray_sdk import global_sdk_config

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -1,5 +1,8 @@
 from aws_xray_sdk.core.plugins.utils import get_plugin_modules
-from mock import patch
+try:
+    from unittest.mock import patch
+except ImportError:
+    from mock import patch  # Python 2
 
 supported_plugins = (
     'ec2_plugin',

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -2,7 +2,8 @@ from aws_xray_sdk.core.plugins.utils import get_plugin_modules
 try:
     from unittest.mock import patch
 except ImportError:
-    from mock import patch  # Python 2
+    # NOTE: Python 2 dependency
+    from mock import patch
 
 supported_plugins = (
     'ec2_plugin',

--- a/tox.ini
+++ b/tox.ini
@@ -37,7 +37,7 @@ deps =
     testing.mysqld
     webtest
     # Python2 only deps
-    py{27}: enum34, mock
+    py{27}: enum34 mock
 
     # pymysql deps
     py{27,34,35}: pymysql < 1.0.0

--- a/tox.ini
+++ b/tox.ini
@@ -36,10 +36,8 @@ deps =
     testing.postgresql
     testing.mysqld
     webtest
-    mock ; python_version < '3.3'
-
     # Python2 only deps
-    py{27}: enum34
+    py{27}: enum34, mock
 
     # pymysql deps
     py{27,34,35}: pymysql < 1.0.0

--- a/tox.ini
+++ b/tox.ini
@@ -36,7 +36,7 @@ deps =
     testing.postgresql
     testing.mysqld
     webtest
-    mock
+    mock ; python_version < '3.3'
 
     # Python2 only deps
     py{27}: enum34


### PR DESCRIPTION
Use `unittest.mock` from the standard library where available.

*Issue #, if available:* *N/A*

*Description of changes:*

Conditionally require the PyPI `mock` backport package in `tox.ini`: instead of always, only for Python versions older than 3.3.

Wherever `mock` or `unittest.mock` is imported, support either.

See https://fedoraproject.org/wiki/Changes/DeprecatePythonMock for context.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
