### PR TITLE
Improving CI for running tests

### DIFF
--- a/.github/workflows/UnitTesting.yaml
+++ b/.github/workflows/UnitTesting.yaml
@@ -1,0 +1,53 @@
+name: Unit Testing
+on:
+  push:
+    branches:
+      - master
+      - fix_ci
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  test:
+    # "setup-python" action doesn't provide python 3.4 binaries for ubuntu-latest.
+    # Sticking to Ubuntu 18.04 as recommended here:
+    # https://github.com/actions/setup-python/issues/185#issuecomment-768232756
+    runs-on: ubuntu-18.04
+    env:
+      py27: 2.7
+      py34: 3.4
+      py35: 3.5
+      py36: 3.6
+      py37: 3.7
+      py38: 3.8
+      py39: 3.9
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: [py27, py34, py35, py36, py37, py38, py39]
+        testenv: [core, ext]
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ env[matrix.python-version] }}
+
+      - name: Install tox
+        run: pip install -U tox-factor
+
+      - name: Cache tox environment
+        # Preserves .tox directory between runs for faster installs
+        uses: actions/cache@v2
+        with:
+          path: |
+            .tox
+            ~/.cache/pip
+          key: tox-cache-${{ matrix.python-version }}-${{ matrix.testenv }}-${{ hashFiles('tox.ini') }}
+
+      - name: Run tox
+        run: |
+          tox -f ${{ matrix.python-version }}-${{ matrix.testenv }}

--- a/.github/workflows/UnitTesting.yaml
+++ b/.github/workflows/UnitTesting.yaml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - master
-      - fix_ci
   pull_request:
     branches:
       - master

--- a/aws_xray_sdk/core/sampling/local/sampler.py
+++ b/aws_xray_sdk/core/sampling/local/sampler.py
@@ -5,7 +5,7 @@ from random import Random
 from .sampling_rule import SamplingRule
 from ...exceptions.exceptions import InvalidSamplingManifestError
 
-local_sampling_rule = json.loads(pkgutil.get_data(__name__, 'sampling_rule.json'))
+local_sampling_rule = json.loads(pkgutil.get_data(__name__, 'sampling_rule.json').decode('utf-8'))
 
 SUPPORTED_RULE_VERSION = (1, 2)
 

--- a/aws_xray_sdk/core/sampling/local/sampler.py
+++ b/aws_xray_sdk/core/sampling/local/sampler.py
@@ -5,6 +5,7 @@ from random import Random
 from .sampling_rule import SamplingRule
 from ...exceptions.exceptions import InvalidSamplingManifestError
 
+# `.decode('utf-8')` needed for Python 3.4, 3.5.
 local_sampling_rule = json.loads(pkgutil.get_data(__name__, 'sampling_rule.json').decode('utf-8'))
 
 SUPPORTED_RULE_VERSION = (1, 2)

--- a/aws_xray_sdk/ext/boto_utils.py
+++ b/aws_xray_sdk/ext/boto_utils.py
@@ -12,7 +12,7 @@ from aws_xray_sdk.core.exceptions.exceptions import SegmentNotFoundException
 from aws_xray_sdk.ext.util import inject_trace_header, to_snake_case
 
 
-whitelist = json.loads(pkgutil.get_data(__name__, 'resources/aws_para_whitelist.json'))
+whitelist = json.loads(pkgutil.get_data(__name__, 'resources/aws_para_whitelist.json').decode('utf-8'))
 
 
 def inject_header(wrapped, instance, args, kwargs):

--- a/aws_xray_sdk/ext/boto_utils.py
+++ b/aws_xray_sdk/ext/boto_utils.py
@@ -11,7 +11,7 @@ from aws_xray_sdk.core.exceptions.exceptions import SegmentNotFoundException
 
 from aws_xray_sdk.ext.util import inject_trace_header, to_snake_case
 
-
+# `.decode('utf-8')` needed for Python 3.4, 3.5
 whitelist = json.loads(pkgutil.get_data(__name__, 'resources/aws_para_whitelist.json').decode('utf-8'))
 
 

--- a/tests/ext/aiobotocore/test_aiobotocore.py
+++ b/tests/ext/aiobotocore/test_aiobotocore.py
@@ -1,6 +1,7 @@
 import pytest
 
 import aiobotocore
+from aiobotocore.session import get_session
 from botocore.stub import Stubber, ANY
 from botocore.exceptions import ClientError
 
@@ -28,7 +29,7 @@ async def test_describe_table(loop, recorder):
     req_id = '1234'
     response = {'ResponseMetadata': {'RequestId': req_id, 'HTTPStatusCode': 403}}
 
-    session = aiobotocore.get_session()
+    session = get_session()
     async with session.create_client('dynamodb', region_name='eu-west-2') as client:
         with Stubber(client) as stubber:
             stubber.add_response('describe_table', response, {'TableName': 'mytable'})
@@ -53,7 +54,7 @@ async def test_s3_parameter_capture(loop, recorder):
     version_id = 'myversionid'
     response = {'ResponseMetadata': {'RequestId': '1234', 'HTTPStatusCode': 200}}
 
-    session = aiobotocore.get_session()
+    session = get_session()
     async with session.create_client('s3', region_name='eu-west-2') as client:
         with Stubber(client) as stubber:
             stubber.add_response('get_object', response,
@@ -87,7 +88,7 @@ async def test_list_parameter_counting(loop, recorder):
         }
     }
 
-    session = aiobotocore.get_session()
+    session = get_session()
     async with session.create_client('sqs', region_name='eu-west-2') as client:
         with Stubber(client) as stubber:
             stubber.add_response('list_queues', response, {'QueueNamePrefix': queue_name_prefix})
@@ -117,7 +118,7 @@ async def test_map_parameter_grouping(loop, recorder):
         }
     }
 
-    session = aiobotocore.get_session()
+    session = get_session()
     async with session.create_client('dynamodb', region_name='eu-west-2') as client:
         with Stubber(client) as stubber:
             stubber.add_response('batch_write_item', response, {'RequestItems': ANY})
@@ -137,7 +138,7 @@ async def test_context_missing_not_swallow_return(loop, recorder):
 
     response = {'ResponseMetadata': {'RequestId': '1234', 'HTTPStatusCode': 403}}
 
-    session = aiobotocore.get_session()
+    session = get_session()
     async with session.create_client('dynamodb', region_name='eu-west-2') as client:
         with Stubber(client) as stubber:
             stubber.add_response('describe_table', response, {'TableName': 'mytable'})
@@ -150,7 +151,7 @@ async def test_context_missing_not_suppress_exception(loop, recorder):
     xray_recorder.configure(service='test', sampling=False,
                             context=AsyncContext(loop=loop), context_missing='LOG_ERROR')
 
-    session = aiobotocore.get_session()
+    session = get_session()
     async with session.create_client('dynamodb', region_name='eu-west-2') as client:
         with Stubber(client) as stubber:
             stubber.add_client_error('describe_table', expected_params={'TableName': ANY})

--- a/tests/ext/aiobotocore/test_aiobotocore.py
+++ b/tests/ext/aiobotocore/test_aiobotocore.py
@@ -1,6 +1,5 @@
 import pytest
 
-import aiobotocore
 from aiobotocore.session import get_session
 from botocore.stub import Stubber, ANY
 from botocore.exceptions import ClientError

--- a/tests/test_local_sampling_benchmark.py
+++ b/tests/test_local_sampling_benchmark.py
@@ -5,6 +5,7 @@ from pkg_resources import resource_filename
 # Faster
 def test_pkgutil_static_read(benchmark):
     def get_sampling_rule():
+        # `.decode('utf-8')` needed for Python 3.4, 3.5
         return json.loads(pkgutil.get_data(__name__, 'mock_sampling_rule.json').decode('utf-8'))
     benchmark(get_sampling_rule)
 

--- a/tests/test_local_sampling_benchmark.py
+++ b/tests/test_local_sampling_benchmark.py
@@ -5,7 +5,7 @@ from pkg_resources import resource_filename
 # Faster
 def test_pkgutil_static_read(benchmark):
     def get_sampling_rule():
-        return json.loads(pkgutil.get_data(__name__, 'mock_sampling_rule.json'))
+        return json.loads(pkgutil.get_data(__name__, 'mock_sampling_rule.json').decode('utf-8'))
     benchmark(get_sampling_rule)
 
 # Slower

--- a/tox.ini
+++ b/tox.ini
@@ -1,19 +1,49 @@
 [tox]
-envlist =
-    py{27,34,35,36,37,38,39}-default
-    py{35,36,37,38,39}-aiohttp2
-    py{35,36,37,38,39}-django22
-    py{36,37,38,39}-django30
-    py{36,37,38,39}-django31
-    py{36,37,38,39}-django32
-    py{27,36,37,38,39}-sqlalchemy
-    py{34,35}-sqlalchemy
-    coverage-report
-
 skip_missing_interpreters = True
+envlist =
+    py{27,34,35,36,37,38,39}-core
+
+    ; Unavailable for python 2.7 & 3.4
+    py{35,36,37,38,39}-ext-aiobotocore
+
+    ; Unavailable for python 2.7 & 3.4
+    py{35,36,37,38,39}-ext-aiohttp
+
+    py{27,34,35,36,37,38,39}-ext-botocore
+
+    py{27,34,35,36,37,38,39}-ext-bottle
+
+    ; Django2 is only for python 3.6+
+    py{35,36,37,38,39}-ext-django-2
+
+    ; Django3 is only for python 3.6+
+    py{36,37,38,39}-ext-django-3
+
+    py{27,34,35,36,37,38,39}-ext-flask
+
+    py{27,34,35,36,37,38,39}-ext-flask_sqlalchemy
+
+    py{27,34,35,36,37,38,39}-ext-httplib
+
+    py{27,34,35,36,37,38,39}-ext-pg8000
+
+    py{27,34,35,36,37,38,39}-ext-psycopg2
+
+    py{27,34,35,36,37,38,39}-ext-pymysql
+
+    py{27,34,35,36,37,38,39}-ext-pynamodb
+
+    py{27,34,35,36,37,38,39}-ext-requests
+
+    py{27,34,35,36,37,38,39}-ext-sqlalchemy
+
+    py{27,34,35,36,37,38,39}-ext-sqlalchemy_core
+
+    py{27,34,35,36,37,38,39}-ext-sqlite3
 
 [testenv]
-passenv = TOXENV CI TRAVIS TRAVIS_* CODECOV_*
+passenv = TOXENV CI CODECOV_*
+
 deps =
     pytest > 3.0.0
     pytest-benchmark
@@ -25,98 +55,75 @@ deps =
     sqlalchemy
     Flask-SQLAlchemy
     future
-    django22: Django==2.2.*
-    django30: Django==3.0.*
-    django31: Django==3.1.*
-    django32: Django==3.2.*
-    django{22,30,31,32}: django-fake-model
+    django-2: Django>=2.0,<3.0
+    django-3: Django>=3.0,<4.0
+    django-{2,3}: django-fake-model
     pynamodb >= 3.3.1
     psycopg2
-    pg8000
+    pg8000 <=1.20.0
     testing.postgresql
     testing.mysqld
     webtest
-    # Python2 only deps
-    py{27}: enum34 mock
+    wrapt
+
+    ; Python 2.7 only deps
+    py{27}: enum34
+    py{27}: mock
 
     # pymysql deps
     py{27,34,35}: pymysql < 1.0.0
     py{36,37,38,39}: pymysql >= 1.0.0
 
-    # Python3.4 only deps
+    # Python 3.4 only deps
     py34: typing >= 3.7.4.3
 
-    # Python3.5+ only deps
+    # Python 3.5+ only deps
     py{35,36,37,38,39}: aiohttp >= 3.0.0
     py{35,36,37,38,39}: pytest-aiohttp
     py{35,36,37,38,39}: aiobotocore >= 0.10.0
-
-commands =
-    coverage erase
-    py{27,34}-default: coverage run --append --source aws_xray_sdk -m py.test tests --ignore tests/ext/aiohttp --ignore tests/ext/aiobotocore --ignore tests/ext/django --ignore tests/test_async_local_storage.py --ignore tests/test_async_recorder.py --ignore tests/ext/sqlalchemy_core
-    py{35,36,37,38,39}-default: coverage run --append --source aws_xray_sdk -m py.test tests --ignore tests/ext/django --ignore tests/ext/sqlalchemy_core
-    py{27,36,37,38,39}-default: coverage run --append --source aws_xray_sdk -m py.test tests/ext/sqlalchemy_core
-    py{34,35}-default: coverage run --append --source aws_xray_sdk -m py.test tests/ext/sqlalchemy_core/ --ignore tests/ext/sqlalchemy_core/test_sqlalchemy_core_2.py
-    django{22,30,31,32}: coverage run --append --source aws_xray_sdk -m py.test tests/ext/django
-    codecov
 
 setenv =
     DJANGO_SETTINGS_MODULE = tests.ext.django.app.settings
     AWS_SECRET_ACCESS_KEY = fake_key
     AWS_ACCESS_KEY_ID=fake_id
 
-[testenv:py35-aiohttp2]
-deps =
-    pytest > 3.0.0
-    aiohttp >= 2.3.0,<3.0.0
-    pytest-aiohttp
-    botocore
-    coverage==4.5.4
-
 commands =
-    py{35}: coverage run --source aws_xray_sdk -m py.test tests/ext/aiohttp --ignore tests/ext/aiohttp/test_client.py
+    coverage erase
 
-[testenv:py36-aiohttp2]
-deps =
-    pytest > 3.0.0
-    aiohttp >= 2.3.0,<3.0.0
-    pytest-aiohttp
-    botocore
-    coverage==4.5.4
+    ; Async methods are only available for python 3.5+
+    py{27,34}-core: coverage run --append --source aws_xray_sdk -m pytest --ignore tests/ext --ignore tests/test_async_local_storage.py --ignore tests/test_async_recorder.py
+    py{35,36,37,38,39}-core: coverage run --append --source aws_xray_sdk -m pytest --ignore tests/ext
 
-commands =
-    py{36}: coverage run --source aws_xray_sdk -m py.test tests/ext/aiohttp --ignore tests/ext/aiohttp/test_client.py
+    ext-aiobotocore: coverage run --append --source aws_xray_sdk -m pytest tests/ext/aiobotocore
 
-[testenv:py37-aiohttp2]
-deps =
-    pytest > 3.0.0
-    aiohttp >= 2.3.0,<3.0.0
-    pytest-aiohttp
-    botocore
-    coverage==4.5.4
+    ext-aiohttp: coverage run --append --source aws_xray_sdk -m pytest tests/ext/aiohttp
 
-commands =
-    py{37}: coverage run --source aws_xray_sdk -m py.test tests/ext/aiohttp --ignore tests/ext/aiohttp/test_client.py
+    ext-botocore: coverage run --append --source aws_xray_sdk -m pytest tests/ext/botocore
 
-[testenv:py38-aiohttp2]
-deps =
-    pytest > 5.2.0
-    aiohttp >= 3.6
-    pytest-aiohttp
-    botocore
-    coverage==4.5.4
+    ext-bottle: coverage run --append --source aws_xray_sdk -m pytest tests/ext/bottle
 
-commands =
-    py{38}: coverage run --source aws_xray_sdk -m py.test tests/ext/aiohttp --ignore tests/ext/aiohttp/test_client.py
+    ext-django: coverage run --append --source aws_xray_sdk -m pytest tests/ext/django
 
-[testenv:coverage-report]
-deps = coverage
-skip_install = true
-commands =
-    # might need to add coverage combine at some point
-    py{38}: coverage report
-    py{38}: coverage html
+    ext-flask: coverage run --append --source aws_xray_sdk -m pytest tests/ext/flask
 
-[flake8]
-max-line-length=120
-exclude=tests
+    ext-flask_sqlalchemy: coverage run --append --source aws_xray_sdk -m pytest tests/ext/flask_sqlalchemy
+
+    ext-httplib: coverage run --append --source aws_xray_sdk -m pytest tests/ext/httplib
+
+    ext-pg8000: coverage run --append --source aws_xray_sdk -m pytest tests/ext/pg8000
+
+    ext-psycopg2: coverage run --append --source aws_xray_sdk -m pytest tests/ext/psycopg2
+
+    ext-pymysql: coverage run --append --source aws_xray_sdk -m pytest tests/ext/pymysql
+
+    ext-pynamodb: coverage run --append --source aws_xray_sdk -m pytest tests/ext/pynamodb
+
+    ext-requests: coverage run --append --source aws_xray_sdk -m pytest tests/ext/requests
+
+    ext-sqlalchemy: coverage run --append --source aws_xray_sdk -m pytest tests/ext/sqlalchemy
+
+    ; 2.0 style execution is not supported for python 3.4 & 3.5
+    py{27,36,37,38,39}-ext-sqlalchemy_core: coverage run --append --source aws_xray_sdk -m pytest tests/ext/sqlalchemy_core
+    py{34,35}-ext-sqlalchemy_core: coverage run --append --source aws_xray_sdk -m pytest tests/ext/sqlalchemy_core --ignore tests/ext/sqlalchemy_core/test_sqlalchemy_core_2.py
+
+    ext-sqlite3: coverage run --append --source aws_xray_sdk -m pytest tests/ext/sqlite3

--- a/tox.ini
+++ b/tox.ini
@@ -63,9 +63,9 @@ deps =
     py34: typing >= 3.7.4.3
 
     ; Python 3.5+ only deps
-;    py{35,36,37,38,39}: aiohttp >= 3.0.0
-;    py{35,36,37,38,39}: pytest-aiohttp
-;    py{35,36,37,38,39}: aiobotocore >= 0.10.0
+    py{35,36,37,38,39}: aiohttp >= 3.0.0
+    py{35,36,37,38,39}: pytest-aiohttp
+    py{35,36,37,38,39}: aiobotocore >= 0.10.0
 
     ext-aiobotocore: aiobotocore>=0.10.0
 
@@ -85,7 +85,7 @@ deps =
     ext-sqlalchemy: sqlalchemy
 
     ext-sqlalchemy_core: sqlalchemy
-    ext-sqlalchemy: testing.postgresql
+    ext-sqlalchemy_core: testing.postgresql
 
     ext-django-2: Django>=2.0,<3.0
     ext-django-3: Django>=3.0,<4.0

--- a/tox.ini
+++ b/tox.ini
@@ -48,7 +48,7 @@ deps =
     ; Testing packages
     pytest > 3.0.0
     pytest-benchmark
-    coverage==4.5.4
+    coverage == 4.5.4
     codecov
 
     ; Packages common to all test environments
@@ -63,23 +63,26 @@ deps =
     py34: typing >= 3.7.4.3
 
     ; Python 3.5+ only deps
-    ; for some reason required for core
+    ; for some reason pytest-aiohttp is required for "core" tests
+    ; TODO: find and replace by more direct dependency
     py{35,36,37,38,39}: pytest-aiohttp
 
-    ext-aiobotocore: aiobotocore>=0.10.0
+    ext-aiobotocore: aiobotocore >= 0.10.0
     ext-aiobotocore: pytest-aiohttp
 
-    ext-aiohttp: aiohttp>=3.0.0
-    ext-aiohttp: pytest-aiohttp
+    ext-aiohttp: aiohttp >= 3.0.0
+    ; Breaking change where the `test_client` fixture was renamed.
+    ; Also, the stable version is only supported for Python 3.7+
+    ext-aiohttp: pytest-aiohttp < 1.0.0
 
     ext-requests: requests
 
-    ext-bottle: bottle>=0.10
+    ext-bottle: bottle >= 0.10
     ext-bottle: webtest
 
-    ext-flask: flask>=0.10
+    ext-flask: flask >= 0.10
 
-    ext-flask_sqlalchemy: flask>=0.10
+    ext-flask_sqlalchemy: flask >= 0.10
     ext-flask_sqlalchemy: Flask-SQLAlchemy
 
     ext-sqlalchemy: sqlalchemy
@@ -88,8 +91,8 @@ deps =
     ext-sqlalchemy_core: testing.postgresql
     ext-sqlalchemy_core: psycopg2
 
-    ext-django-2: Django>=2.0,<3.0
-    ext-django-3: Django>=3.0,<4.0
+    ext-django-2: Django >=2.0,<3.0
+    ext-django-3: Django >=3.0,<4.0
     ext-django: django-fake-model
 
     ext-pynamodb: pynamodb >= 3.3.1
@@ -97,7 +100,7 @@ deps =
     ext-psycopg2: psycopg2
     ext-psycopg2: testing.postgresql
 
-    ext-pg8000: pg8000<=1.20.0
+    ext-pg8000: pg8000 <= 1.20.0
     ext-pg8000: testing.postgresql
 
     ext-pymysql: testing.mysqld

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ envlist =
 
     py{27,34,35,36,37,38,39}-ext-bottle
 
-    ; Django2 is only for python 3.6+
+    ; Django2 (2.2+) is only for python 3.5 +
     py{35,36,37,38,39}-ext-django-2
 
     ; Django3 is only for python 3.6+
@@ -45,42 +45,56 @@ envlist =
 passenv = TOXENV CI CODECOV_*
 
 deps =
+    ; Testing packages
     pytest > 3.0.0
     pytest-benchmark
     coverage==4.5.4
     codecov
-    requests
-    bottle >= 0.10
-    flask >= 0.10
-    sqlalchemy
-    Flask-SQLAlchemy
+
+    ; Packages common to all test environments
     future
-    django-2: Django>=2.0,<3.0
-    django-3: Django>=3.0,<4.0
-    django-{2,3}: django-fake-model
-    pynamodb >= 3.3.1
-    psycopg2
-    pg8000 <=1.20.0
-    testing.postgresql
-    testing.mysqld
-    webtest
     wrapt
 
     ; Python 2.7 only deps
-    py{27}: enum34
-    py{27}: mock
+    py{27}: enum34 mock
 
-    # pymysql deps
-    py{27,34,35}: pymysql < 1.0.0
-    py{36,37,38,39}: pymysql >= 1.0.0
-
-    # Python 3.4 only deps
+    ; Python 3.4 only deps
     py34: typing >= 3.7.4.3
 
-    # Python 3.5+ only deps
-    py{35,36,37,38,39}: aiohttp >= 3.0.0
-    py{35,36,37,38,39}: pytest-aiohttp
-    py{35,36,37,38,39}: aiobotocore >= 0.10.0
+    ; Python 3.5+ only deps
+;    py{35,36,37,38,39}: aiohttp >= 3.0.0
+;    py{35,36,37,38,39}: pytest-aiohttp
+;    py{35,36,37,38,39}: aiobotocore >= 0.10.0
+
+    ext-aiobotocore: aiobotocore>=0.10.0
+
+    ext-aiohttp: aiohttp>=3.0.0 pytest-aiohttp
+
+    ext-requests: requests
+
+    ext-bottle: bottle>=0.10 webtest
+
+    ext-flask: flask>=0.10
+
+    ext-flask_sqlalchemy: flask>=0.10 Flask-SQLAlchemy
+
+    ext-sqlalchemy: sqlalchemy
+
+    ext-sqlalchemy_core: sqlalchemy testing.postgresql
+
+    ext-django-2: Django>=2.0,<3.0
+    ext-django-3: Django>=3.0,<4.0
+    ext-django: django-fake-model
+
+    ext-pynamodb: pynamodb >= 3.3.1
+
+    ext-psycopg2: psycopg2 testing.postgresql
+
+    ext-pg8000: pg8000<=1.20.0 testing.postgresql
+
+    ext-pymysql: testing.mysqld
+    py{27,34,35}-ext-pymysql: pymysql < 1.0.0
+    py{36,37,38,39}-ext-pymysql: pymysql >= 1.0.0
 
 setenv =
     DJANGO_SETTINGS_MODULE = tests.ext.django.app.settings
@@ -122,8 +136,11 @@ commands =
 
     ext-sqlalchemy: coverage run --append --source aws_xray_sdk -m pytest tests/ext/sqlalchemy
 
-    ; 2.0 style execution is not supported for python 3.4 & 3.5
+    ; sqlalchemy_core - 2.0 style execution is not supported for python 3.4 & 3.5
     py{27,36,37,38,39}-ext-sqlalchemy_core: coverage run --append --source aws_xray_sdk -m pytest tests/ext/sqlalchemy_core
     py{34,35}-ext-sqlalchemy_core: coverage run --append --source aws_xray_sdk -m pytest tests/ext/sqlalchemy_core --ignore tests/ext/sqlalchemy_core/test_sqlalchemy_core_2.py
 
     ext-sqlite3: coverage run --append --source aws_xray_sdk -m pytest tests/ext/sqlite3
+
+    ; TODO: add additional logic to combine coverage from "core" and "ext" test runs
+    ; codecov

--- a/tox.ini
+++ b/tox.ini
@@ -63,11 +63,12 @@ deps =
     py34: typing >= 3.7.4.3
 
     ; Python 3.5+ only deps
-    py{35,36,37,38,39}: aiohttp >= 3.0.0
-    py{35,36,37,38,39}: pytest-aiohttp
-    py{35,36,37,38,39}: aiobotocore >= 0.10.0
+;    py{35,36,37,38,39}: aiohttp >= 3.0.0
+;    py{35,36,37,38,39}: pytest-aiohttp
+;    py{35,36,37,38,39}: aiobotocore >= 0.10.0
 
     ext-aiobotocore: aiobotocore>=0.10.0
+    ext-aiobotocore: pytest-aiohttp
 
     ext-aiohttp: aiohttp>=3.0.0
     ext-aiohttp: pytest-aiohttp
@@ -86,6 +87,7 @@ deps =
 
     ext-sqlalchemy_core: sqlalchemy
     ext-sqlalchemy_core: testing.postgresql
+    ext-sqlalchemy_core: psycopg2
 
     ext-django-2: Django>=2.0,<3.0
     ext-django-3: Django>=3.0,<4.0

--- a/tox.ini
+++ b/tox.ini
@@ -56,7 +56,8 @@ deps =
     wrapt
 
     ; Python 2.7 only deps
-    py{27}: enum34 mock
+    py{27}: enum34
+    py{27}: mock
 
     ; Python 3.4 only deps
     py34: typing >= 3.7.4.3
@@ -68,19 +69,23 @@ deps =
 
     ext-aiobotocore: aiobotocore>=0.10.0
 
-    ext-aiohttp: aiohttp>=3.0.0 pytest-aiohttp
+    ext-aiohttp: aiohttp>=3.0.0
+    ext-aiohttp: pytest-aiohttp
 
     ext-requests: requests
 
-    ext-bottle: bottle>=0.10 webtest
+    ext-bottle: bottle>=0.10
+    ext-bottle: webtest
 
     ext-flask: flask>=0.10
 
-    ext-flask_sqlalchemy: flask>=0.10 Flask-SQLAlchemy
+    ext-flask_sqlalchemy: flask>=0.10
+    ext-flask_sqlalchemy: Flask-SQLAlchemy
 
     ext-sqlalchemy: sqlalchemy
 
-    ext-sqlalchemy_core: sqlalchemy testing.postgresql
+    ext-sqlalchemy_core: sqlalchemy
+    ext-sqlalchemy: testing.postgresql
 
     ext-django-2: Django>=2.0,<3.0
     ext-django-3: Django>=3.0,<4.0
@@ -88,9 +93,11 @@ deps =
 
     ext-pynamodb: pynamodb >= 3.3.1
 
-    ext-psycopg2: psycopg2 testing.postgresql
+    ext-psycopg2: psycopg2
+    ext-psycopg2: testing.postgresql
 
-    ext-pg8000: pg8000<=1.20.0 testing.postgresql
+    ext-pg8000: pg8000<=1.20.0
+    ext-pg8000: testing.postgresql
 
     ext-pymysql: testing.mysqld
     py{27,34,35}-ext-pymysql: pymysql < 1.0.0

--- a/tox.ini
+++ b/tox.ini
@@ -63,9 +63,8 @@ deps =
     py34: typing >= 3.7.4.3
 
     ; Python 3.5+ only deps
-;    py{35,36,37,38,39}: aiohttp >= 3.0.0
-;    py{35,36,37,38,39}: pytest-aiohttp
-;    py{35,36,37,38,39}: aiobotocore >= 0.10.0
+    ; for some reason required for core
+    py{35,36,37,38,39}: pytest-aiohttp
 
     ext-aiobotocore: aiobotocore>=0.10.0
     ext-aiobotocore: pytest-aiohttp


### PR DESCRIPTION
*Issue:*
The Python SDK CI which used Travis had been having issues like builds not triggering or getting stuck, etc for a while. 

*Description of changes:*
- Switching to using GH workflow to run the test suite on PR and push to `master`
- Refactored `tox.ini` to simplify the structure of test suite. Now the tests are split into "**core**" which tests the main core logic of the SDK, and "**ext**" which tests all the library instrumentations. Both combinations are run for a set of different python versions (2.7 to 3.9)
- Some changes worth mentioning:
  - Explicitly decoding the input to `json.loads()` to UTF-8 because python 3.4 and 3.5 will break the API with following  error. Python 3.6+ do this automatically but being explicit doesn't hurt here.
      ```
      TypeError: the JSON object must be str, not 'bytes'
      ```
  - Had to pin pg8000 to v1.20.0 or less as in the newer versions the [`_server_version`](https://github.com/aws/aws-xray-sdk-python/blob/71436ad7f275c603298da68bee072af7c214cfc3/aws_xray_sdk/ext/pg8000/patch.py#L27) attribute on the connection object is not present and the [assertion](https://github.com/aws/aws-xray-sdk-python/blob/71436ad7f275c603298da68bee072af7c214cfc3/tests/ext/pg8000/test_pg8000.py#L50) for `database_version` fails.
- You can find the sample workflow execution for these changes in my fork: https://github.com/srprash/aws-xray-sdk-python/actions/runs/1689686594
- _Note:_ I have removed the generation and publishing of code coverage report in this PR as we would mostly need additional logic to combine coverage from "core" and "ext" test runs. This should be a follow up improvement.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
