### PR TITLE
Document pg8000 <= 1.20.0 requirement

### DIFF
--- a/aws_xray_sdk/ext/pg8000/README.md
+++ b/aws_xray_sdk/ext/pg8000/README.md
@@ -1,0 +1,3 @@
+## Requirements
+
+Only compatible with `pg8000 <= 1.20.0`.


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

Follow up to #322 which said

> Had to pin pg8000 to v1.20.0 or less as in the newer versions the _server_version attribute on the connection object is not present and the assertion for database_version fails.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
