### PR TITLE
Remove distutils.util.strtobool deprecated in PEP 632 (Python 3.10)

### DIFF
--- a/aws_xray_sdk/sdk_config.py
+++ b/aws_xray_sdk/sdk_config.py
@@ -1,6 +1,5 @@
 import os
 import logging
-from distutils.util import strtobool
 
 log = logging.getLogger(__name__)
 
@@ -40,10 +39,12 @@ class SDKConfig(object):
 
         :return: bool - True if it is enabled, False otherwise.
         """
-        env_var_str = os.getenv(cls.XRAY_ENABLED_KEY, 'true')
-        try:
-            return bool(strtobool(env_var_str))
-        except ValueError:
+        env_var_str = os.getenv(cls.XRAY_ENABLED_KEY, 'true').lower()
+        if env_var_str in ('y', 'yes', 't', 'true', 'on', '1'):
+            return True
+        elif env_var_str in ('n', 'no', 'f', 'false', 'off', '0'):
+            return False
+        else:
             log.warning("Invalid literal passed into environment variable `AWS_XRAY_SDK_ENABLED`. Defaulting to True...")
             return True  # If an invalid parameter is passed in, we return True.
 


### PR DESCRIPTION
*Description of changes:*
[PEP 632](https://peps.python.org/pep-0632/) deprecates `distutils` in Python 3.10, and recommends specifically that `distutils.util.strtobool` be replaced by reimplementing it, which I have done here to preserve existing behaviour.

Related to: #321

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
