### PR TITLE
Add TCP emitter

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ default emitter, you will see log messages like `OSError: [Errno 90] Message too
 you may want to use the TCP emitter instead:
 
 ```python
-from aws_xray_sdk.core.emitter.tcp_emitter import TCPEmitter
+from aws_xray_sdk.core.emitters.tcp_emitter import TCPEmitter
 from aws_xray_sdk.core import xray_recorder
 
 xray_recorder.configure(emitter=TCPEmitter())

--- a/README.md
+++ b/README.md
@@ -192,6 +192,19 @@ if xray_recorder.is_sampled():
     xray_recorder.put_metadata('mykey', metadata)
 ```
 
+### Using the TCP emitter
+
+In the event your application creates segments in excess of 64kb (using the
+default emitter, you will see log messages like `OSError: [Errno 90] Message too long`)
+you may want to use the TCP emitter instead:
+
+```python
+from aws_xray_sdk.core.emitter.tcp_emitter import TCPEmitter
+from aws_xray_sdk.core import xray_recorder
+
+xray_recorder.configure(emitter=TCPEmitter())
+```
+
 ### Generate NoOp Trace and Entity Id
 X-Ray Python SDK will by default generate no-op trace and entity id for unsampled requests and secure random trace and entity id for sampled requests. If customer wants to enable generating secure random trace and entity id for all the (sampled/unsampled) requests (this is applicable for trace id injection into logs use case) then they should set the `AWS_XRAY_NOOP_ID` environment variable as False.
 

--- a/aws_xray_sdk/core/emitters/base.py
+++ b/aws_xray_sdk/core/emitters/base.py
@@ -1,0 +1,61 @@
+import logging
+from abc import ABCMeta, abstractmethod
+
+from .constants import (
+    DEFAULT_DAEMON_ADDRESS,
+    PROTOCOL_DELIMITER,
+    PROTOCOL_HEADER,
+)
+from ..exceptions.exceptions import InvalidDaemonAddressException
+
+log = logging.getLogger(__name__)
+
+
+class Emitter(object):
+
+    __metaclass__ = ABCMeta
+
+    @abstractmethod
+    def __init__(self, daemon_address=DEFAULT_DAEMON_ADDRESS):
+        pass
+
+    def send_entity(self, entity):
+        """
+        Serializes a segment/subsegment and sends it to the X-Ray daemon.
+
+        :param entity: a trace entity to send to the X-Ray daemon
+        """
+        try:
+            message = "%s%s%s" % (PROTOCOL_HEADER,
+                                  PROTOCOL_DELIMITER,
+                                  entity.serialize())
+
+            log.debug("sending: %s to %s:%s." % (message, self._ip, self._port))
+            self._send_data(message)
+        except Exception:
+            log.exception("Failed to send entity to Daemon.")
+
+    @abstractmethod
+    def set_daemon_address(self, address):
+        """
+        Set up ip and port from the raw daemon address.
+        """
+        pass
+
+    @property
+    def ip(self):
+        return self._ip
+
+    @property
+    def port(self):
+        return self._port
+
+    def _send_data(self, data):
+        self._socket.sendto(data.encode('utf-8'), (self._ip, self._port))
+
+    def _parse_address(self, daemon_address):
+        try:
+            val = daemon_address.split(':')
+            return val[0], int(val[1])
+        except Exception:
+            raise InvalidDaemonAddressException('Invalid daemon address %s specified.' % daemon_address)

--- a/aws_xray_sdk/core/emitters/constants.py
+++ b/aws_xray_sdk/core/emitters/constants.py
@@ -1,0 +1,3 @@
+PROTOCOL_HEADER = "{\"format\":\"json\",\"version\":1}"
+PROTOCOL_DELIMITER = '\n'
+DEFAULT_DAEMON_ADDRESS = '127.0.0.1:2000'

--- a/aws_xray_sdk/core/emitters/tcp_emitter.py
+++ b/aws_xray_sdk/core/emitters/tcp_emitter.py
@@ -5,24 +5,24 @@ from .base import Emitter
 from .constants import DEFAULT_DAEMON_ADDRESS
 
 
-class UDPEmitter(Emitter):
+class TCPEmitter(Emitter):
     """
     The default emitter the X-Ray recorder uses to send segments/subsegments
-    to the X-Ray daemon over UDP using a non-blocking socket. If there is an
+    to the X-Ray daemon over TCP using a non-blocking socket. If there is an
     exception on the actual data transfer between the socket and the daemon,
     it logs the exception and continue.
     """
     def __init__(self, daemon_address=DEFAULT_DAEMON_ADDRESS):
 
-        self._socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        self._socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         self._socket.setblocking(0)
         self.set_daemon_address(daemon_address)
 
     def set_daemon_address(self, address):
         """
-        Set up UDP ip and port from the raw daemon address
+        Set up TCP ip and port from the raw daemon address
         string using ``DaemonConfig`` class utlities.
         """
         if address:
             daemon_config = DaemonConfig(address)
-            self._ip, self._port = daemon_config.udp_ip, daemon_config.udp_port
+            self._ip, self._port = daemon_config._ip, daemon_pconfig.tcp_port


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-xray-sdk-python/issues/326

*Description of changes:*
Adds a TCP emitter (in addition to the default UDP emitter) to work around the 64kb frame size limit of UDP.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
