### PR TITLE
Bug Fix: Defensively copy context entities

### DIFF
--- a/aws_xray_sdk/core/async_context.py
+++ b/aws_xray_sdk/core/async_context.py
@@ -110,11 +110,16 @@ def task_factory(loop, coro):
         current_task = asyncio.Task.current_task(loop=loop)
     if current_task is not None and hasattr(current_task, 'context'):
         if current_task.context.get('entities'):
-            # Defensively copying because recorder modifies the list in place.
+            # NOTE: (enowell) Because the `AWSXRayRecorder`'s `Context` decides
+            # the parent by looking at its `_local.entities`, we must copy the entities
+            # for concurrent subsegments. Otherwise, the subsegments would be
+            # modifying the same `entities` list and sugsegments would take other
+            # subsegments as parents instead of the original `segment`.
+            #
+            # See more: https://github.com/aws/aws-xray-sdk-python/blob/0f13101e4dba7b5c735371cb922f727b1d9f46d8/aws_xray_sdk/core/context.py#L90-L101
             new_context = copy.copy(current_task.context)
             new_context['entities'] = [item for item in current_task.context['entities']]
         else:
-            # no reason to copy if there's no entities list.
             new_context = current_task.context
         setattr(task, 'context', new_context)
 

--- a/aws_xray_sdk/core/async_context.py
+++ b/aws_xray_sdk/core/async_context.py
@@ -1,5 +1,6 @@
 import asyncio
 import sys
+import copy
 
 from .context import Context as _Context
 
@@ -108,6 +109,13 @@ def task_factory(loop, coro):
     else:
         current_task = asyncio.Task.current_task(loop=loop)
     if current_task is not None and hasattr(current_task, 'context'):
-        setattr(task, 'context', current_task.context)
+        if current_task.context.get('entities'):
+            # Defensively copying because recorder modifies the list in place.
+            new_context = copy.copy(current_task.context)
+            new_context['entities'] = [item for item in current_task.context['entities']]
+        else:
+            # no reason to copy if there's no entities list.
+            new_context = current_task.context
+        setattr(task, 'context', new_context)
 
     return task

--- a/tests/test_async_recorder.py
+++ b/tests/test_async_recorder.py
@@ -62,9 +62,9 @@ async def test_concurrent_calls(loop):
                     event.set()
                 return subsegment.parent_id
         tasks = [assert_task() for task in range(total_tasks)]
-        results = await asyncio.gather(*tasks)
-        for result in results:
-            assert result == segment.id
+        subsegs_parent_ids = await asyncio.gather(*tasks)
+        for subseg_parent_id in subsegs_parent_ids:
+            assert subseg_parent_id == segment.id
 
 
 async def test_async_context_managers(loop):

--- a/tests/test_async_recorder.py
+++ b/tests/test_async_recorder.py
@@ -50,16 +50,16 @@ async def test_concurrent_calls(loop):
         global counter
         counter = 0
         total_tasks = 10
-        event = asyncio.Event()
+        flag = asyncio.Event()
         async def assert_task():
             async with xray_recorder.in_subsegment_async('segment') as subsegment:
                 global counter
                 counter += 1
-                # Ensure that the task subsegments overlap
+                # Begin all subsegments before closing any to ensure they overlap
                 if counter < total_tasks:
-                    await event.wait()
+                    await flag.wait()
                 else:
-                    event.set()
+                    flag.set()
                 return subsegment.parent_id
         tasks = [assert_task() for task in range(total_tasks)]
         subsegs_parent_ids = await asyncio.gather(*tasks)


### PR DESCRIPTION
# Description

Before this change, concurrent async tasks would all share the same instance of the entities list. This change makes it so they each get their own copy of the list.

This matters because the recorder modifies the `entities` list in place, which makes it so concurrent subtasks end up looking at the wrong item in the `entites` list when deciding the parent subsegment:

https://github.com/aws/aws-xray-sdk-python/blob/0f13101e4dba7b5c735371cb922f727b1d9f46d8/aws_xray_sdk/core/context.py#L90-L101

You can see this in the unit test added. Before this change the unit test would print out the following:

```
Subseg 1 ID: 5b1c1cf70db2e808
Subseg 2 ID: 4a138f09cd3c6813
Subseg 3 ID: f97c02073584be8a
Subseg 4 ID: efac5645672e1cd6
Subseg 5 ID: 6874f083c496d388
Subseg 6 ID: f447815d60c734d6
Subseg 7 ID: edf7d60ea3d6875e
Subseg 8 ID: d2a1980e83a569f4
Subseg 9 ID: 6a0f1059ca4a91b6
Subseg 10 ID: 75421c2a04106214

Parent Segment ID: a9037c7ccc92e0c8 # Correct!
Subseg parent ID: a9037c7ccc92e0c8 # Correct!
Subseg parent ID: 4a138f09cd3c6813 # WRONG (all the ones below are wrong)
Subseg parent ID: f97c02073584be8a
Subseg parent ID: efac5645672e1cd6
Subseg parent ID: 6874f083c496d388
Subseg parent ID: f447815d60c734d6
Subseg parent ID: edf7d60ea3d6875e
Subseg parent ID: d2a1980e83a569f4
Subseg parent ID: 6a0f1059ca4a91b6
Subseg parent ID: 75421c2a04106214
```

With this change, all the subsegments have the correct parent ID.

(enowell) You can also visualize this in X-Ray from my tests:

Before:

<img width="1563" alt="image" src="https://user-images.githubusercontent.com/23139455/176040306-0d47f7a6-72cf-42a2-b082-b0a5ecdfc1aa.png">

Subsegments are children of each other even though they are concurrent:

After:

<img width="1555" alt="image" src="https://user-images.githubusercontent.com/23139455/176040463-c9b4dad1-5498-42dd-b84d-90a7f78eb652.png">

Subsegments have the correct parent ID.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

~I think this possibly fixes the issue here:~

Fixes: #310
Fixes: #164