### PR TITLE
Only import future for py2

### DIFF
--- a/aws_xray_sdk/core/plugins/ec2_plugin.py
+++ b/aws_xray_sdk/core/plugins/ec2_plugin.py
@@ -1,7 +1,11 @@
 import json
 import logging
-from future.standard_library import install_aliases
-install_aliases()
+
+from aws_xray_sdk.core.utils.compat import PY2
+
+if PY2:
+    from future.standard_library import install_aliases
+    install_aliases()
 
 from urllib.request import urlopen, Request
 

--- a/aws_xray_sdk/ext/sqlalchemy/util/decorators.py
+++ b/aws_xray_sdk/ext/sqlalchemy/util/decorators.py
@@ -3,8 +3,13 @@ import types
 
 from aws_xray_sdk.core import xray_recorder
 from aws_xray_sdk.ext.util import strip_url
-from future.standard_library import install_aliases
-install_aliases()
+
+from aws_xray_sdk.core.utils.compat import PY2
+
+if PY2:
+    from future.standard_library import install_aliases
+    install_aliases()
+
 from urllib.parse import urlparse, uses_netloc
 from sqlalchemy.engine.base import Connection
 

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,5 @@
+import sys
+
 from setuptools import setup, find_packages
 from os import path
 from aws_xray_sdk.version import VERSION
@@ -11,6 +13,15 @@ except ImportError:
     read_md = lambda f: open(f, 'r').read()
 
 long_description = read_md(path.join(CURRENT_DIR, 'README.md'))
+
+INSTALL_REQUIRED_DEPS = [
+    'enum34;python_version<"3.4"',
+    'wrapt',
+    'botocore>=1.11.3',
+]
+
+if sys.version_info[0] == 2:
+    INSTALL_REQUIRED_DEPS.append("future")
 
 setup(
     name='aws-xray-sdk',
@@ -44,12 +55,7 @@ setup(
         'Programming Language :: Python :: 3.9',
     ],
 
-    install_requires=[
-        'enum34;python_version<"3.4"',
-        'wrapt',
-        'future',
-        'botocore>=1.11.3',
-    ],
+    install_requires=INSTALL_REQUIRED_DEPS,
 
     keywords='aws xray sdk',
 


### PR DESCRIPTION
*Issue #, if available:* #212

*Description of changes:*

If we only import `future` when the SDK is run on Python 2, then we don't need to import it for `Python 3` systems. This will prevent conflicts with people downloading conflicting versions of the `future` package.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Fixes: #212