### PR TITLE
Remove future from py3 tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -52,12 +52,12 @@ deps =
     codecov
 
     ; Packages common to all test environments
-    future
     wrapt
 
     ; Python 2.7 only deps
     py{27}: enum34
     py{27}: mock
+    py{27}: future
 
     ; Python 3.4 only deps
     py34: typing >= 3.7.4.3


### PR DESCRIPTION
*Issue #, if available:* Follow up to #343

*Description of changes:*

Improved the tests to not include `future` in py3 to validate our `setup.py` changes.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
