### PR TITLE
Fix TypeError by patching register_default_jsonb from psycopg2

### DIFF
--- a/aws_xray_sdk/ext/psycopg2/patch.py
+++ b/aws_xray_sdk/ext/psycopg2/patch.py
@@ -7,7 +7,6 @@ from aws_xray_sdk.ext.dbapi2 import XRayTracedConn, XRayTracedCursor
 
 
 def patch():
-
     wrapt.wrap_function_wrapper(
         'psycopg2',
         'connect',
@@ -24,11 +23,16 @@ def patch():
         _xray_register_type_fix
     )
 
+    wrapt.wrap_function_wrapper(
+        'psycopg2.extras',
+        'register_default_jsonb',
+        _xray_register_default_jsonb_fix
+    )
+
 
 def _xray_traced_connect(wrapped, instance, args, kwargs):
-
     conn = wrapped(*args, **kwargs)
-    parameterized_dsn = { c[0]: c[-1] for c in map(methodcaller('split', '='), conn.dsn.split(' '))}
+    parameterized_dsn = {c[0]: c[-1] for c in map(methodcaller('split', '='), conn.dsn.split(' '))}
     meta = {
         'database_type': 'PostgreSQL',
         'url': 'postgresql://{}@{}:{}/{}'.format(
@@ -44,6 +48,7 @@ def _xray_traced_connect(wrapped, instance, args, kwargs):
 
     return XRayTracedConn(conn, meta)
 
+
 def _xray_register_type_fix(wrapped, instance, args, kwargs):
     """Send the actual connection or curser to register type."""
     our_args = list(copy.copy(args))
@@ -51,3 +56,14 @@ def _xray_register_type_fix(wrapped, instance, args, kwargs):
         our_args[1] = our_args[1].__wrapped__
 
     return wrapped(*our_args, **kwargs)
+
+
+def _xray_register_default_jsonb_fix(wrapped, instance, args, kwargs):
+    our_kwargs = dict()
+    for key, value in kwargs.items():
+        if key == "conn_or_curs" and isinstance(value, (XRayTracedConn, XRayTracedCursor)):
+            # unwrap the connection or cursor to be sent to register_default_jsonb
+            value = value.__wrapped__
+        our_kwargs[key] = value
+
+    return wrapped(*args, **our_kwargs)

--- a/tests/ext/psycopg2/test_psycopg2.py
+++ b/tests/ext/psycopg2/test_psycopg2.py
@@ -173,3 +173,17 @@ def test_query_as_string():
         test_sql = psycopg2.sql.Identifier('test')
         assert test_sql.as_string(conn)
         assert test_sql.as_string(conn.cursor())
+
+
+def test_register_default_jsonb():
+    with testing.postgresql.Postgresql() as postgresql:
+        url = postgresql.url()
+        dsn = postgresql.dsn()
+        conn = psycopg2.connect('dbname=' + dsn['database'] +
+                                ' password=mypassword' +
+                                ' host=' + dsn['host'] +
+                                ' port=' + str(dsn['port']) +
+                                ' user=' + dsn['user'])
+
+        assert psycopg2.extras.register_default_jsonb(conn_or_curs=conn, loads=lambda x: x)
+        assert psycopg2.extras.register_default_jsonb(conn_or_curs=conn.cursor(), loads=lambda x: x)


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws/aws-xray-sdk-python/issues/243

*Description of changes:*
As mentioned in the above issue, [this change](https://github.com/django/django/pull/13358/files#diff-56374f35499bd669398d3100ef7fcea371a8e9e38f92dbd3569d75b8cea2ad93) in Django's newer version calls `psycopg2.extras.register_default_jsonb` which in turn calls `register_type` but our existing patch fails to unwrap the connection to expected type. Therefore resulting in `TypeError: argument 2 must be a connection, cursor or None`.

This PR adds a patch for `register_default_jsonb` so that we unwrap the connection or cursor object (if it's wrapped) and pass it onto the wrapped function.

*Testing:*

The unit test case `test_register_default_jsonb` fails (as expected) when run without the fix but passes with the fix:
```shell
py38-ext-psycopg2 run-test: commands[1] | coverage run --append --source aws_xray_sdk -m pytest tests/ext/psycopg2
================================================================================================================================================= test session starts ==================================================================================================================================================
platform darwin -- Python 3.8.9, pytest-7.1.2, pluggy-1.0.0
cachedir: .tox/py38-ext-psycopg2/.pytest_cache
benchmark: 3.4.1 (defaults: timer=time.perf_counter disable_gc=False min_rounds=5 min_time=0.000005 max_time=1.0 calibration_precision=10 warmup=False warmup_iterations=100000)
rootdir: /Users/srprash/Desktop/Work/XRay_SDK_GH/Python/Fork/aws-xray-sdk-python
plugins: benchmark-3.4.1, asyncio-0.19.0, aiohttp-1.0.4
asyncio: mode=strict
collected 8 items                                                                                                                                                                                                                                                                                                      

tests/ext/psycopg2/test_psycopg2.py .......F                                                                                                                                                                                                                                                                     [100%]

======================================================================================================================================================= FAILURES =======================================================================================================================================================
_____________________________________________________________________________________________________________________________________________ test_register_default_jsonb ______________________________________________________________________________________________________________________________________________

    def test_register_default_jsonb():
        with testing.postgresql.Postgresql() as postgresql:
            url = postgresql.url()
            dsn = postgresql.dsn()
            conn = psycopg2.connect('dbname=' + dsn['database'] +
                                    ' password=mypassword' +
                                    ' host=' + dsn['host'] +
                                    ' port=' + str(dsn['port']) +
                                    ' user=' + dsn['user'])
    
>           assert psycopg2.extras.register_default_jsonb(conn_or_curs=conn, loads=lambda x: x)

tests/ext/psycopg2/test_psycopg2.py:188: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
.tox/py38-ext-psycopg2/lib/python3.8/site-packages/psycopg2/_json.py:150: in register_default_jsonb
    return register_json(conn_or_curs=conn_or_curs, globally=globally,
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

conn_or_curs = <XRayTracedConn at 0x10f7eb240 for psycopg2.extensions.connection at 0x10f23bc10>, globally = False, loads = <function test_register_default_jsonb.<locals>.<lambda> at 0x10fe8ff70>, oid = 3802, array_oid = 3807, name = 'jsonb'

    def register_json(conn_or_curs=None, globally=False, loads=None,
                      oid=None, array_oid=None, name='json'):
        """Create and register typecasters converting :sql:`json` type to Python objects.
    
        :param conn_or_curs: a connection or cursor used to find the :sql:`json`
            and :sql:`json[]` oids; the typecasters are registered in a scope
            limited to this object, unless *globally* is set to `!True`. It can be
            `!None` if the oids are provided
        :param globally: if `!False` register the typecasters only on
            *conn_or_curs*, otherwise register them globally
        :param loads: the function used to parse the data into a Python object. If
            `!None` use `!json.loads()`, where `!json` is the module chosen
            according to the Python version (see above)
        :param oid: the OID of the :sql:`json` type if known; If not, it will be
            queried on *conn_or_curs*
        :param array_oid: the OID of the :sql:`json[]` array type if known;
            if not, it will be queried on *conn_or_curs*
        :param name: the name of the data type to look for in *conn_or_curs*
    
        The connection or cursor passed to the function will be used to query the
        database and look for the OID of the :sql:`json` type (or an alternative
        type if *name* if provided). No query is performed if *oid* and *array_oid*
        are provided.  Raise `~psycopg2.ProgrammingError` if the type is not found.
    
        """
        if oid is None:
            oid, array_oid = _get_json_oids(conn_or_curs, name)
    
        JSON, JSONARRAY = _create_json_typecasters(
            oid, array_oid, loads=loads, name=name.upper())
    
>       register_type(JSON, not globally and conn_or_curs or None)
E       TypeError: argument 2 must be a connection, cursor or None

.tox/py38-ext-psycopg2/lib/python3.8/site-packages/psycopg2/_json.py:120: TypeError


```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
