### PR TITLE
[Fix] Use service parameter to match centralized sampling rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ pip-selfcheck.json
 htmlcov
 
 venv
+.idea

--- a/aws_xray_sdk/core/recorder.py
+++ b/aws_xray_sdk/core/recorder.py
@@ -232,7 +232,7 @@ class AWSXRayRecorder(object):
         elif sampling:
             decision = sampling
         elif self.sampling:
-            decision = self._sampler.should_trace()
+            decision = self._sampler.should_trace({'service': seg_name})
 
         if not decision:
             segment = DummySegment(seg_name)


### PR DESCRIPTION
*Issue #:* https://github.com/aws/aws-xray-sdk-python/issues/352

*Description of changes:*
- Populate the `service` name in the `sampling_req` dictionary so that it can be matched with the centralized sampling rule configured for the service. 

*Testing:*
- Added a unit test `test_begin_segment_matches_sampling_rule_on_name` to verify the behavior.
  - Unit test result without the fix:
     ```
     ============================= test session starts ==============================
     collecting ... collected 1 item

     tests/test_recorder.py::test_begin_segment_matches_sampling_rule_on_name FAILED [100%]
     tests/test_recorder.py:315 (test_begin_segment_matches_sampling_rule_on_name)
     'rule_a' != 'rule_b'

     Expected :'rule_b'
     Actual   :'rule_a'
     ```

  - Unit test result after the fix:
     ```
     ============================= test session starts ==============================
     collecting ... collected 1 item

     tests/test_recorder.py::test_begin_segment_matches_sampling_rule_on_name PASSED [100%]
     ```
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
