### PR TITLE
Implement PEP3134 to discover underlying problems with python3

### DIFF
--- a/aws_xray_sdk/core/async_recorder.py
+++ b/aws_xray_sdk/core/async_recorder.py
@@ -1,4 +1,5 @@
 import time
+import six
 
 from aws_xray_sdk.core.recorder import AWSXRayRecorder
 from aws_xray_sdk.core.utils import stacktrace
@@ -81,10 +82,10 @@ class AsyncAWSXRayRecorder(AWSXRayRecorder):
         try:
             return_value = await wrapped(*args, **kwargs)
             return return_value
-        except Exception as e:
-            exception = e
+        except Exception as exc:
+            exception = exc
             stack = stacktrace.get_stacktrace(limit=self._max_trace_back)
-            raise
+            six.raise_from(exc, exc)
         finally:
             # No-op if subsegment is `None` due to `LOG_ERROR`.
             if subsegment is not None:

--- a/aws_xray_sdk/core/patcher.py
+++ b/aws_xray_sdk/core/patcher.py
@@ -6,6 +6,7 @@ import pkgutil
 import re
 import sys
 import wrapt
+import six
 
 from aws_xray_sdk import global_sdk_config
 from .utils.compat import PY2, is_classmethod, is_instance_method
@@ -107,9 +108,9 @@ def patch(modules_to_patch, raise_errors=True, ignore_module_patterns=None):
 def _patch_module(module_to_patch, raise_errors=True):
     try:
         _patch(module_to_patch)
-    except Exception:
+    except Exception as exc:
         if raise_errors:
-            raise
+            six.raise_from(exc, exc)
         log.debug('failed to patch module %s', module_to_patch)
 
 

--- a/aws_xray_sdk/core/recorder.py
+++ b/aws_xray_sdk/core/recorder.py
@@ -4,6 +4,7 @@ import logging
 import os
 import platform
 import time
+import six
 
 from aws_xray_sdk import global_sdk_config
 from aws_xray_sdk.version import VERSION
@@ -435,10 +436,10 @@ class AWSXRayRecorder(object):
         try:
             return_value = wrapped(*args, **kwargs)
             return return_value
-        except Exception as e:
-            exception = e
+        except Exception as exc:
+            exception = exc
             stack = stacktrace.get_stacktrace(limit=self.max_trace_back)
-            raise
+            six.raise_from(exc, exc)
         finally:
             # No-op if subsegment is `None` due to `LOG_ERROR`.
             if subsegment is not None:

--- a/aws_xray_sdk/ext/aiohttp/middleware.py
+++ b/aws_xray_sdk/ext/aiohttp/middleware.py
@@ -1,3 +1,5 @@
+import six
+
 """
 AioHttp Middleware
 """
@@ -64,14 +66,14 @@ async def middleware(request, handler):
     except HTTPException as exc:
         # Non 2XX responses are raised as HTTPExceptions
         response = exc
-        raise
-    except Exception as err:
+        six.raise_from(exc, exc)
+    except Exception as exc:
         # Store exception information including the stacktrace to the segment
         response = None
         segment.put_http_meta(http.STATUS, 500)
         stack = stacktrace.get_stacktrace(limit=xray_recorder.max_trace_back)
-        segment.add_exception(err, stack)
-        raise
+        segment.add_exception(exc, stack)
+        six.raise_from(exc, exc)
     finally:
         if response is not None:
             segment.put_http_meta(http.STATUS, response.status)

--- a/aws_xray_sdk/ext/sqlalchemy_core/patch.py
+++ b/aws_xray_sdk/ext/sqlalchemy_core/patch.py
@@ -1,12 +1,13 @@
 import logging
 import sys
+import wrapt
+import six
 
 if sys.version_info >= (3, 0, 0):
     from urllib.parse import urlparse, uses_netloc
 else:
     from urlparse import urlparse, uses_netloc
 
-import wrapt
 
 from aws_xray_sdk.core import xray_recorder
 from aws_xray_sdk.core.patcher import _PATCHED_MODULES
@@ -72,12 +73,12 @@ def _process_request(wrapped, engine_instance, args, kwargs):
         subsegment = None
     try:
         res = wrapped(*args, **kwargs)
-    except Exception:
+    except Exception as exc:
         if subsegment is not None:
             exception = sys.exc_info()[1]
             stack = stacktrace.get_stacktrace(limit=xray_recorder._max_trace_back)
             subsegment.add_exception(exception, stack)
-        raise
+        six.raise_from(exc, exc)
     finally:
         if subsegment is not None:
             subsegment.set_sql(sql)


### PR DESCRIPTION
*Issue #, if available:*
#354 

*Description of changes:*
Implement PEP3134 through [six.raise_from](https://six.readthedocs.io/index.html?highlight=raise_from#six.raise_from) to support python2 and python3.

Also move one import to top of the module to better comply with pylint (C0413:wrong-import-position)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
