### PR TITLE
Fix UnboundLocalError when aiohttp server raises a CancelledError

### DIFF
--- a/aws_xray_sdk/ext/aiohttp/middleware.py
+++ b/aws_xray_sdk/ext/aiohttp/middleware.py
@@ -67,7 +67,7 @@ async def middleware(request, handler):
         # Non 2XX responses are raised as HTTPExceptions
         response = exc
         six.raise_from(exc, exc)
-    except Exception as exc:
+    except BaseException as exc:
         # Store exception information including the stacktrace to the segment
         response = None
         segment.put_http_meta(http.STATUS, 500)


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* In `aiohttp` middleware, catch `BaseException` instead of `Exception` to avoid `UnboundLocalError`.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
