### PR TITLE
Version pinning flask-sqlalchemy version to 2.5.1 or less

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -83,7 +83,7 @@ deps =
     ext-flask: flask >= 0.10
 
     ext-flask_sqlalchemy: flask >= 0.10
-    ext-flask_sqlalchemy: Flask-SQLAlchemy
+    ext-flask_sqlalchemy: Flask-SQLAlchemy <= 2.5.1
 
     ext-sqlalchemy: sqlalchemy
 


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-xray-sdk-python/issues/359




By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
