### PR TITLE
Run tests against Django 4.x

### DIFF
--- a/tests/ext/django/app/views.py
+++ b/tests/ext/django/app/views.py
@@ -1,7 +1,7 @@
 import sqlite3
 
 from django.http import HttpResponse
-from django.conf.urls import url
+from django.urls import path
 from django.views.generic import TemplateView
 
 
@@ -32,9 +32,9 @@ def call_db(request):
 
 
 urlpatterns = [
-    url(r'^200ok/$', ok, name='200ok'),
-    url(r'^500fault/$', fault, name='500fault'),
-    url(r'^call_db/$', call_db, name='call_db'),
-    url(r'^template/$', IndexView.as_view(), name='template'),
-    url(r'^template_block/$', TemplateBlockView.as_view(), name='template_block'),
+    path('200ok/', ok, name='200ok'),
+    path('500fault/', fault, name='500fault'),
+    path('call_db/', call_db, name='call_db'),
+    path('template/', IndexView.as_view(), name='template'),
+    path('template_block/', TemplateBlockView.as_view(), name='template_block'),
 ]

--- a/tox.ini
+++ b/tox.ini
@@ -19,6 +19,9 @@ envlist =
     ; Django3 is only for python 3.6+
     py{36,37,38,39}-ext-django-3
 
+    ; Django4 is only for python 3.8+
+    py{38,39}-ext-django-4
+
     py{27,34,35,36,37,38,39}-ext-flask
 
     py{27,34,35,36,37,38,39}-ext-flask_sqlalchemy
@@ -98,6 +101,7 @@ deps =
 
     ext-django-2: Django >=2.0,<3.0
     ext-django-3: Django >=3.0,<4.0
+    ext-django-4: Django >=4.0,<5.0
     ext-django: django-fake-model
 
     ext-pynamodb: pynamodb >= 3.3.1


### PR DESCRIPTION
Django 4.0 was [released](https://www.djangoproject.com/weblog/2021/dec/07/django-40-released/) in December 2021 and Django [4.1](https://www.djangoproject.com/weblog/2022/aug/03/django-41-released/) in August 2022.  Both are non-LTS releases.  The next LTS will be 4.2 (the last release in the 4.x series) which is expected in April 2023.

*Issue #, if available:* n/a

*Description of changes:*  Adjust tox.ini and update test imports for Django 4 compatibility.  (The updated import works with all releases since Django 2.0, see django/django#7482.)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
