### PR TITLE
[LambdaContext] persist original trace header

### DIFF
--- a/aws_xray_sdk/core/lambda_launcher.py
+++ b/aws_xray_sdk/core/lambda_launcher.py
@@ -142,5 +142,6 @@ class LambdaContext(Context):
             entityid=trace_header.parent,
             sampled=sampled,
         )
+        segment.save_origin_trace_header(trace_header)
         setattr(self._local, 'segment', segment)
         setattr(self._local, 'entities', [])


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
The `save_origin_trace_header` method is used to persist the original trace header on the trace entity. This original trace header can later be retrieved ([example](https://github.com/aws/aws-xray-sdk-python/blob/80dbd1d122d7244c300b63f3675360da5c61eff6/aws_xray_sdk/ext/util.py#L33-L48)) for the `data` field for passing through to downstreams.
We are not currently persisting the original trace header in Lambda context entity. So, when a trace header like `Root=1-5759e988-bd862e3fe1be46a994272793;Parent=53995c3f42cd8ad8;Sampled=1;Foo=Bar` is received by Lambda, the `Foo=Bar` data part is dropped when building the trace header. This PR ensures that the original trace header is persisted in the FacadeSegment on Lambda.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
