### PR TITLE
Oversampling Mitigation

### DIFF
--- a/aws_xray_sdk/core/models/dummy_entities.py
+++ b/aws_xray_sdk/core/models/dummy_entities.py
@@ -11,7 +11,7 @@ class DummySegment(Segment):
     the segment based on sampling rules.
     Adding data to a dummy segment becomes a no-op except for
     subsegments. This is to reduce the memory footprint of the SDK.
-    A dummy segment will not be sent to the X-Ray daemon. Manually create
+    A dummy segment will not be sent to the X-Ray daemon. Manually creating
     dummy segments is not recommended.
     """
 

--- a/aws_xray_sdk/core/models/entity.py
+++ b/aws_xray_sdk/core/models/entity.py
@@ -81,6 +81,7 @@ class Entity(object):
         """
         self._check_ended()
         subsegment.parent_id = self.id
+        subsegment.sampled = self.sampled if subsegment.sampled == True else False
         self.subsegments.append(subsegment)
 
     def remove_subsegment(self, subsegment):

--- a/aws_xray_sdk/core/models/entity.py
+++ b/aws_xray_sdk/core/models/entity.py
@@ -81,7 +81,10 @@ class Entity(object):
         """
         self._check_ended()
         subsegment.parent_id = self.id
-        subsegment.sampled = self.sampled if subsegment.sampled == True else False
+
+        if not self.sampled and subsegment.sampled:
+            log.warning("This sampled subsegment is being added to an unsampled parent segment/subsegment and will be orphaned.")
+
         self.subsegments.append(subsegment)
 
     def remove_subsegment(self, subsegment):

--- a/aws_xray_sdk/core/recorder.py
+++ b/aws_xray_sdk/core/recorder.py
@@ -284,6 +284,8 @@ class AWSXRayRecorder(object):
 
         :param str name: the name of the subsegment.
         :param str namespace: currently can only be 'local', 'remote', 'aws'.
+        :param bool sampling: sampling decision for the subsegment being created,
+            defaults to True
         """
         # Generating the parent dummy segment is necessary.
         # We don't need to store anything in context. Assumption here

--- a/aws_xray_sdk/core/recorder.py
+++ b/aws_xray_sdk/core/recorder.py
@@ -275,7 +275,7 @@ class AWSXRayRecorder(object):
         else:
             return entity
 
-    def _begin_subsegment_helper(self, name, namespace='local', beginWithoutSampling=False):
+    def _begin_subsegment_helper(self, name, namespace, beginWithoutSampling=False):
         '''
         Helper method to begin_subsegment and begin_subsegment_without_sampling
         '''
@@ -311,7 +311,7 @@ class AWSXRayRecorder(object):
         :param str name: the name of the subsegment.
         :param str namespace: currently can only be 'local', 'remote', 'aws'.
         """
-        return self._begin_subsegment_helper(name)
+        return self._begin_subsegment_helper(name, namespace)
 
 
     def begin_subsegment_without_sampling(self, name):

--- a/aws_xray_sdk/core/recorder.py
+++ b/aws_xray_sdk/core/recorder.py
@@ -275,7 +275,7 @@ class AWSXRayRecorder(object):
         else:
             return entity
 
-    def _begin_subsegment_helper(self, name, namespace, beginWithoutSampling=False):
+    def _begin_subsegment_helper(self, name, namespace='local', beginWithoutSampling=False):
         '''
         Helper method to begin_subsegment and begin_subsegment_without_sampling
         '''

--- a/aws_xray_sdk/core/utils/sqs_message_helper.py
+++ b/aws_xray_sdk/core/utils/sqs_message_helper.py
@@ -1,10 +1,11 @@
+SQS_XRAY_HEADER = "AWSTraceHeader"
 class SqsMessageHelper:
     
     @staticmethod 
     def isSampled(sqs_message):
         attributes = sqs_message['attributes']
 
-        if 'AWSTraceHeader' not in attributes:
+        if SQS_XRAY_HEADER not in attributes:
             return False
 
-        return 'Sampled=1' in attributes['AWSTraceHeader']
+        return 'Sampled=1' in attributes[SQS_XRAY_HEADER]

--- a/aws_xray_sdk/core/utils/sqs_message_helper.py
+++ b/aws_xray_sdk/core/utils/sqs_message_helper.py
@@ -1,0 +1,10 @@
+class SqsMessageHelper:
+    
+    @staticmethod 
+    def isSampled(sqs_message):
+        attributes = sqs_message['attributes']
+
+        if 'AWSTraceHeader' not in attributes:
+            return False
+
+        return 'Sampled=1' in attributes['AWSTraceHeader']

--- a/aws_xray_sdk/ext/util.py
+++ b/aws_xray_sdk/ext/util.py
@@ -35,7 +35,6 @@ def inject_trace_header(headers, entity):
     else:
         header = entity.get_origin_trace_header()
     data = header.data if header else None
-    
     to_insert = TraceHeader(
         root=entity.trace_id,
         parent=entity.id,

--- a/aws_xray_sdk/ext/util.py
+++ b/aws_xray_sdk/ext/util.py
@@ -35,7 +35,7 @@ def inject_trace_header(headers, entity):
     else:
         header = entity.get_origin_trace_header()
     data = header.data if header else None
-
+    
     to_insert = TraceHeader(
         root=entity.trace_id,
         parent=entity.id,

--- a/tests/test_facade_segment.py
+++ b/tests/test_facade_segment.py
@@ -70,21 +70,3 @@ def test_adding_unsampled_subsegment():
     assert segment.subsegments[0] is subsegment
     assert subsegment.subsegments[0] is subsegment2
     assert subsegment2.sampled == False
-
-def test_adding_subsegment_respects_parent_sampling_decision():
-
-    segment = FacadeSegment('name', 'id', 'id', True)
-    subsegment = Subsegment('sampled', 'local', segment)
-    subsegment2 = Subsegment('unsampled', 'local', segment)
-    subsegment2.sampled = False
-    
-    subsegment3 = Subsegment('unsampled-child', 'local', segment)
-    segment.add_subsegment(subsegment)
-    subsegment.add_subsegment(subsegment2)
-
-    subsegment2.add_subsegment(subsegment3)
-
-    assert segment.subsegments[0] is subsegment
-    assert subsegment.subsegments[0] is subsegment2
-    assert subsegment2.sampled == False
-    assert subsegment3.sampled == False

--- a/tests/test_facade_segment.py
+++ b/tests/test_facade_segment.py
@@ -55,3 +55,36 @@ def test_structure_intact():
 
     assert segment.subsegments[0] is subsegment
     assert subsegment.subsegments[0] is subsegment2
+
+def test_adding_unsampled_subsegment():
+
+    segment = FacadeSegment('name', 'id', 'id', True)
+    subsegment = Subsegment('sampled', 'local', segment)
+    subsegment2 = Subsegment('unsampled', 'local', segment)
+    subsegment2.sampled = False
+
+    segment.add_subsegment(subsegment)
+    subsegment.add_subsegment(subsegment2)
+
+
+    assert segment.subsegments[0] is subsegment
+    assert subsegment.subsegments[0] is subsegment2
+    assert subsegment2.sampled == False
+
+def test_adding_subsegment_respects_parent_sampling_decision():
+
+    segment = FacadeSegment('name', 'id', 'id', True)
+    subsegment = Subsegment('sampled', 'local', segment)
+    subsegment2 = Subsegment('unsampled', 'local', segment)
+    subsegment2.sampled = False
+    
+    subsegment3 = Subsegment('unsampled-child', 'local', segment)
+    segment.add_subsegment(subsegment)
+    subsegment.add_subsegment(subsegment2)
+
+    subsegment2.add_subsegment(subsegment3)
+
+    assert segment.subsegments[0] is subsegment
+    assert subsegment.subsegments[0] is subsegment2
+    assert subsegment2.sampled == False
+    assert subsegment3.sampled == False

--- a/tests/test_recorder.py
+++ b/tests/test_recorder.py
@@ -145,7 +145,7 @@ def test_unsampled_subsegment_of_sampled_parent():
     xray_recorder = get_new_stubbed_recorder()
     xray_recorder.configure(sampling=True)
     segment = xray_recorder.begin_segment('name', sampling=True)
-    subsegment = xray_recorder.begin_subsegment('unsampled', sampling=False)
+    subsegment = xray_recorder.begin_subsegment_without_sampling('unsampled')
 
     assert segment.sampled == True
     assert subsegment.sampled == False
@@ -154,7 +154,7 @@ def test_begin_subsegment_unsampled():
     xray_recorder = get_new_stubbed_recorder()
     xray_recorder.configure(sampling=False)
     segment = xray_recorder.begin_segment('name', sampling=False)
-    subsegment = xray_recorder.begin_subsegment('unsampled', sampling=False)
+    subsegment = xray_recorder.begin_subsegment_without_sampling('unsampled')
 
     assert segment.sampled == False
     assert subsegment.sampled == False
@@ -222,14 +222,14 @@ def test_disable_is_dummy():
 def test_unsampled_subsegment_is_dummy():
     assert global_sdk_config.sdk_enabled()
     segment = xray_recorder.begin_segment('name')
-    subsegment = xray_recorder.begin_subsegment('name', sampling=False)
+    subsegment = xray_recorder.begin_subsegment_without_sampling('name')
     
     assert type(xray_recorder.current_subsegment()) is DummySubsegment
 
 def test_subsegment_respects_parent_sampling_decision():
     assert global_sdk_config.sdk_enabled()
     segment = xray_recorder.begin_segment('name')
-    subsegment = xray_recorder.begin_subsegment('name2', sampling=False)
+    subsegment = xray_recorder.begin_subsegment_without_sampling('name2')
     subsegment2 = xray_recorder.begin_subsegment('unsampled-subsegment')
 
     assert type(xray_recorder.current_subsegment()) is DummySubsegment

--- a/tests/test_recorder.py
+++ b/tests/test_recorder.py
@@ -141,6 +141,24 @@ def test_first_begin_segment_sampled():
 
     assert segment.sampled
 
+def test_unsampled_subsegment_of_sampled_parent():
+    xray_recorder = get_new_stubbed_recorder()
+    xray_recorder.configure(sampling=True)
+    segment = xray_recorder.begin_segment('name', sampling=True)
+    subsegment = xray_recorder.begin_subsegment('unsampled', sampling=False)
+
+    assert segment.sampled == True
+    assert subsegment.sampled == False
+
+def test_begin_subsegment_unsampled():
+    xray_recorder = get_new_stubbed_recorder()
+    xray_recorder.configure(sampling=False)
+    segment = xray_recorder.begin_segment('name', sampling=False)
+    subsegment = xray_recorder.begin_subsegment('unsampled', sampling=False)
+
+    assert segment.sampled == False
+    assert subsegment.sampled == False
+
 
 def test_in_segment_closing():
     xray_recorder = get_new_stubbed_recorder()
@@ -200,6 +218,23 @@ def test_disable_is_dummy():
     subsegment = xray_recorder.begin_subsegment('name')
     assert type(xray_recorder.current_segment()) is DummySegment
     assert type(xray_recorder.current_subsegment()) is DummySubsegment
+
+def test_unsampled_subsegment_is_dummy():
+    assert global_sdk_config.sdk_enabled()
+    segment = xray_recorder.begin_segment('name')
+    subsegment = xray_recorder.begin_subsegment('name', sampling=False)
+    
+    assert type(xray_recorder.current_subsegment()) is DummySubsegment
+
+def test_subsegment_respects_parent_sampling_decision():
+    assert global_sdk_config.sdk_enabled()
+    segment = xray_recorder.begin_segment('name')
+    subsegment = xray_recorder.begin_subsegment('name2', sampling=False)
+    subsegment2 = xray_recorder.begin_subsegment('unsampled-subsegment')
+
+    assert type(xray_recorder.current_subsegment()) is DummySubsegment
+    assert subsegment.sampled == False
+    assert subsegment2.sampled == False
 
 
 def test_disabled_empty_context_current_calls():

--- a/tests/test_sqs_message_helper.py
+++ b/tests/test_sqs_message_helper.py
@@ -1,0 +1,68 @@
+from aws_xray_sdk.core.utils.sqs_message_helper import SqsMessageHelper
+
+import pytest
+
+sampleSqsMessageEvent = {
+        "Records": [
+            {
+                "messageId": "059f36b4-87a3-44ab-83d2-661975830a7d",
+                "receiptHandle": "AQEBwJnKyrHigUMZj6rYigCgxlaS3SLy0a...",
+                "body": "Test message.",
+                "attributes": {
+                    "ApproximateReceiveCount": "1",
+                    "SentTimestamp": "1545082649183",
+                    "SenderId": "AIDAIENQZJOLO23YVJ4VO",
+                    "ApproximateFirstReceiveTimestamp": "1545082649185",
+                    "AWSTraceHeader":"Root=1-632BB806-bd862e3fe1be46a994272793;Sampled=1"
+                },
+                "messageAttributes": {},
+                "md5OfBody": "e4e68fb7bd0e697a0ae8f1bb342846b3",
+                "eventSource": "aws:sqs",
+                "eventSourceARN": "arn:aws:sqs:us-east-2:123456789012:my-queue",
+                "awsRegion": "us-east-2"
+            },
+            {
+                "messageId": "2e1424d4-f796-459a-8184-9c92662be6da",
+                "receiptHandle": "AQEBzWwaftRI0KuVm4tP+/7q1rGgNqicHq...",
+                "body": "Test message.",
+                "attributes": {
+                    "ApproximateReceiveCount": "1",
+                    "SentTimestamp": "1545082650636",
+                    "SenderId": "AIDAIENQZJOLO23YVJ4VO",
+                    "ApproximateFirstReceiveTimestamp": "1545082650649",
+                    "AWSTraceHeader":"Root=1-5759e988-bd862e3fe1be46a994272793;Parent=53995c3f42cd8ad8;Sampled=0"
+                },
+                "messageAttributes": {},
+                "md5OfBody": "e4e68fb7bd0e697a0ae8f1bb342846b3",
+                "eventSource": "aws:sqs",
+                "eventSourceARN": "arn:aws:sqs:us-east-2:123456789012:my-queue",
+                "awsRegion": "us-east-2"
+            },
+            {
+                "messageId": "2e1424d4-f796-459a-8184-9c92662be6da",
+                "receiptHandle": "AQEBzWwaftRI0KuVm4tP+/7q1rGgNqicHq...",
+                "body": "Test message.",
+                "attributes": {
+                    "ApproximateReceiveCount": "1",
+                    "SentTimestamp": "1545082650636",
+                    "SenderId": "AIDAIENQZJOLO23YVJ4VO",
+                    "ApproximateFirstReceiveTimestamp": "1545082650649",
+                    "AWSTraceHeader":"Root=1-5759e988-bd862e3fe1be46a994272793;Parent=53995c3f42cd8ad8"
+                },
+                "messageAttributes": {},
+                "md5OfBody": "e4e68fb7bd0e697a0ae8f1bb342846b3",
+                "eventSource": "aws:sqs",
+                "eventSourceARN": "arn:aws:sqs:us-east-2:123456789012:my-queue",
+                "awsRegion": "us-east-2"
+            }
+        ]
+    }
+
+def test_return_true_when_sampling_1():
+    assert SqsMessageHelper.isSampled(sampleSqsMessageEvent['Records'][0]) == True
+
+def test_return_false_when_sampling_0():
+    assert SqsMessageHelper.isSampled(sampleSqsMessageEvent['Records'][1]) == False
+
+def test_return_false_with_no_sampling_flag():
+    assert SqsMessageHelper.isSampled(sampleSqsMessageEvent['Records'][2]) == False

--- a/tests/test_trace_entities.py
+++ b/tests/test_trace_entities.py
@@ -288,29 +288,6 @@ def test_adding_unsampled_subsegment_to_subsegment():
     assert subsegment.sampled == True
     assert subsubsegment.sampled == False
 
-def test_adding_subsegment_respects_parent_sampling():
-    segment = Segment('seg')
-    subsegment = Subsegment('sub', 'local', segment)
-    subsegment.sampled = False
-    segment.add_subsegment(subsegment)
-    subsubsegment = Subsegment('subsub', 'local', segment)
-    subsegment.add_subsegment(subsubsegment)
-
-    assert segment.sampled == True
-    assert subsegment.sampled == False
-    assert subsubsegment.sampled == False
-
-def test_adding_subsegment_respects_parent_sampling2():
-    segment = Segment('seg')
-    subsegment = Subsegment('sub', 'local', segment)
-    segment.add_subsegment(subsegment)
-    subsubsegment = Subsegment('subsub', 'local', segment)
-    subsegment.add_subsegment(subsubsegment)
-
-    assert segment.sampled == True
-    assert subsegment.sampled == True
-    assert subsubsegment.sampled == True
-
 def test_adding_subsegments_with_recorder():
     xray_recorder.configure(sampling=False)
     xray_recorder.clear_trace_entities()

--- a/tests/test_trace_entities.py
+++ b/tests/test_trace_entities.py
@@ -267,27 +267,6 @@ def test_add_exception_appending_exceptions():
     assert isinstance(segment.cause, dict)
     assert len(segment.cause['exceptions']) == 2
 
-def test_adding_unsampled_subsegment():
-    segment = Segment('seg')
-    subsegment = Subsegment('sub', 'local', segment)
-    subsegment.sampled = False
-    segment.add_subsegment(subsegment)
-
-    assert subsegment.sampled == False
-    assert segment.sampled == True
-
-def test_adding_unsampled_subsegment_to_subsegment():
-    segment = Segment('seg')
-    subsegment = Subsegment('sub', 'local', segment)
-    segment.add_subsegment(subsegment)
-    subsubsegment = Subsegment('subsub', 'local', segment)
-    subsubsegment.sampled = False
-    subsegment.add_subsegment(subsubsegment)
-
-    assert segment.sampled == True
-    assert subsegment.sampled == True
-    assert subsubsegment.sampled == False
-
 def test_adding_subsegments_with_recorder():
     xray_recorder.configure(sampling=False)
     xray_recorder.clear_trace_entities()

--- a/tests/test_trace_entities.py
+++ b/tests/test_trace_entities.py
@@ -11,6 +11,9 @@ from aws_xray_sdk.core.exceptions.exceptions import SegmentNotFoundException
 from aws_xray_sdk.core.exceptions.exceptions import AlreadyEndedException
 
 from .util import entity_to_dict
+from .util import get_new_stubbed_recorder
+
+xray_recorder = get_new_stubbed_recorder()
 
 
 def test_unicode_entity_name():
@@ -307,3 +310,19 @@ def test_adding_subsegment_respects_parent_sampling2():
     assert segment.sampled == True
     assert subsegment.sampled == True
     assert subsubsegment.sampled == True
+
+def test_adding_subsegments_with_recorder():
+    xray_recorder.configure(sampling=False)
+    xray_recorder.clear_trace_entities()
+    
+    segment = xray_recorder.begin_segment('parent');
+    subsegment = xray_recorder.begin_subsegment('sampled-child')
+    unsampled_subsegment = xray_recorder.begin_subsegment_without_sampling('unsampled-child1')
+    unsampled_child_subsegment = xray_recorder.begin_subsegment('unsampled-child2')
+
+    assert segment.sampled == True
+    assert subsegment.sampled == True
+    assert unsampled_subsegment.sampled == False
+    assert unsampled_child_subsegment.sampled == False
+
+    xray_recorder.clear_trace_entities()

--- a/tests/test_trace_entities.py
+++ b/tests/test_trace_entities.py
@@ -263,3 +263,47 @@ def test_add_exception_appending_exceptions():
 
     assert isinstance(segment.cause, dict)
     assert len(segment.cause['exceptions']) == 2
+
+def test_adding_unsampled_subsegment():
+    segment = Segment('seg')
+    subsegment = Subsegment('sub', 'local', segment)
+    subsegment.sampled = False
+    segment.add_subsegment(subsegment)
+
+    assert subsegment.sampled == False
+    assert segment.sampled == True
+
+def test_adding_unsampled_subsegment_to_subsegment():
+    segment = Segment('seg')
+    subsegment = Subsegment('sub', 'local', segment)
+    segment.add_subsegment(subsegment)
+    subsubsegment = Subsegment('subsub', 'local', segment)
+    subsubsegment.sampled = False
+    subsegment.add_subsegment(subsubsegment)
+
+    assert segment.sampled == True
+    assert subsegment.sampled == True
+    assert subsubsegment.sampled == False
+
+def test_adding_subsegment_respects_parent_sampling():
+    segment = Segment('seg')
+    subsegment = Subsegment('sub', 'local', segment)
+    subsegment.sampled = False
+    segment.add_subsegment(subsegment)
+    subsubsegment = Subsegment('subsub', 'local', segment)
+    subsegment.add_subsegment(subsubsegment)
+
+    assert segment.sampled == True
+    assert subsegment.sampled == False
+    assert subsubsegment.sampled == False
+
+def test_adding_subsegment_respects_parent_sampling2():
+    segment = Segment('seg')
+    subsegment = Subsegment('sub', 'local', segment)
+    segment.add_subsegment(subsegment)
+    subsubsegment = Subsegment('subsub', 'local', segment)
+    subsegment.add_subsegment(subsubsegment)
+
+    assert segment.sampled == True
+    assert subsegment.sampled == True
+    assert subsubsegment.sampled == True

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -65,7 +65,7 @@ def test_inject_trace_header_unsampled():
     xray_recorder = get_new_stubbed_recorder()
     xray_recorder.configure(sampling=True)
     segment = xray_recorder.begin_segment('name', sampling=True)
-    subsegment = xray_recorder.begin_subsegment('unsampled', sampling=False)
+    subsegment = xray_recorder.begin_subsegment_without_sampling('unsampled')
 
     inject_trace_header(headers, subsegment)
 
@@ -77,7 +77,7 @@ def test_inject_trace_header_respects_parent_subsegment():
     xray_recorder = get_new_stubbed_recorder()
     xray_recorder.configure(sampling=True)
     segment = xray_recorder.begin_segment('name', sampling=True)
-    subsegment = xray_recorder.begin_subsegment('unsampled', sampling=False)
+    subsegment = xray_recorder.begin_subsegment_without_sampling('unsampled')
     subsegment2 = xray_recorder.begin_subsegment('unsampled2')
     inject_trace_header(headers, subsegment2)
 


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Implemented oversampling mitigation to support creating subsegments without sampling (control sampling decisions at the subsegment level) and an SQS message helper class. 

Note: Since it is possible to modify the `sampled` flag of a subsegment without the need to create a new API, this is the design implemented in the changes below. For instance, to create a new _unsampled_ subsegment and add it to a Lambda facade segment: 
```
    segment = FacadeSegment('facade_segment', 'id', 'id', True)
    subsegment = Subsegment('sampled_subsegment', 'local', segment)
    subsegment.sampled = False
    segment.add_subsegment(subsegment)
```

Similarly, the `begin_subsegment` API has been modified to include a default `sampling` parameter which defaults to `True`, and can be set to `False` when creating a new unsampled subsegment. 
```
    segment = xray_recorder.begin_segment('segment')
    subsegment = xray_recorder.begin_subsegment('unsampled_subsegment', sampling=False)
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
