### PR TITLE
Modified context missing strategy default to log error

### DIFF
--- a/aws_xray_sdk/core/context.py
+++ b/aws_xray_sdk/core/context.py
@@ -27,7 +27,7 @@ class Context(object):
 
     This data structure is thread-safe.
     """
-    def __init__(self, context_missing='RUNTIME_ERROR'):
+    def __init__(self, context_missing='LOG_ERROR'):
 
         self._local = threading.local()
         strategy = os.getenv(CXT_MISSING_STRATEGY_KEY, context_missing)

--- a/aws_xray_sdk/ext/django/conf.py
+++ b/aws_xray_sdk/ext/django/conf.py
@@ -6,7 +6,7 @@ from django.test.signals import setting_changed
 DEFAULTS = {
     'AWS_XRAY_DAEMON_ADDRESS': '127.0.0.1:2000',
     'AUTO_INSTRUMENT': True,
-    'AWS_XRAY_CONTEXT_MISSING': 'RUNTIME_ERROR',
+    'AWS_XRAY_CONTEXT_MISSING': 'LOG_ERROR',
     'PLUGINS': (),
     'SAMPLING': True,
     'SAMPLING_RULES': None,

--- a/docs/frameworks.rst
+++ b/docs/frameworks.rst
@@ -39,7 +39,7 @@ The default values are as follows::
     XRAY_RECORDER = {
         'AWS_XRAY_DAEMON_ADDRESS': '127.0.0.1:2000',
         'AUTO_INSTRUMENT': True,  # If turned on built-in database queries and template rendering will be recorded as subsegments
-        'AWS_XRAY_CONTEXT_MISSING': 'RUNTIME_ERROR',
+        'AWS_XRAY_CONTEXT_MISSING': 'LOG_ERROR',
         'PLUGINS': (),
         'SAMPLING': True,
         'SAMPLING_RULES': None,

--- a/tests/ext/django/test_db.py
+++ b/tests/ext/django/test_db.py
@@ -10,8 +10,7 @@ from aws_xray_sdk.ext.django.db import patch_db
 @pytest.fixture(scope='module', autouse=True)
 def setup():
     django.setup()
-    xray_recorder.configure(context=Context(),
-                            context_missing='LOG_ERROR')
+    xray_recorder.configure(context=Context())
     patch_db()
 
 

--- a/tests/ext/django/test_middleware.py
+++ b/tests/ext/django/test_middleware.py
@@ -15,8 +15,7 @@ class XRayTestCase(TestCase):
 
     def setUp(self):
         django.setup()
-        xray_recorder.configure(context=Context(),
-                                context_missing='LOG_ERROR')
+        xray_recorder.configure(context=Context())
         xray_recorder.clear_trace_entities()
         global_sdk_config.set_sdk_enabled(True)
 

--- a/tests/test_recorder.py
+++ b/tests/test_recorder.py
@@ -13,6 +13,7 @@ from aws_xray_sdk import global_sdk_config
 from aws_xray_sdk.core.models.segment import Segment
 from aws_xray_sdk.core.models.subsegment import Subsegment
 from aws_xray_sdk.core.models.dummy_entities import DummySegment, DummySubsegment
+from aws_xray_sdk.core.exceptions.exceptions import SegmentNotFoundException
 
 xray_recorder = get_new_stubbed_recorder()
 
@@ -99,19 +100,26 @@ def test_put_annotation_metadata():
     assert not subsegment.metadata['default'].get('key1')
 
 
-def test_pass_through_with_missing_context():
+def test_default_pass_through_with_missing_context():
     xray_recorder = get_new_stubbed_recorder()
-    xray_recorder.configure(sampling=False, context_missing='LOG_ERROR')
+    xray_recorder.configure(sampling=False) # default context_missing = 'LOG_ERROR'
     assert not xray_recorder.is_sampled()
 
     xray_recorder.put_annotation('key', 'value')
     xray_recorder.put_metadata('key', 'value')
     xray_recorder.end_segment()
 
+def test_raise_runtime_error_with_missing_context():
+    xray_recorder = get_new_stubbed_recorder()
+    xray_recorder.configure(sampling=False, context_missing='RUNTIME_ERROR')
+
+    with pytest.raises(SegmentNotFoundException):
+        assert not xray_recorder.is_sampled()
+        xray_recorder.end_segment()
 
 def test_capture_not_suppress_exception():
     xray_recorder = get_new_stubbed_recorder()
-    xray_recorder.configure(sampling=False, context_missing='LOG_ERROR')
+    xray_recorder.configure(sampling=False)
 
     @xray_recorder.capture()
     def buggy_func():
@@ -123,7 +131,7 @@ def test_capture_not_suppress_exception():
 
 def test_capture_not_swallow_return():
     xray_recorder = get_new_stubbed_recorder()
-    xray_recorder.configure(sampling=False, context_missing='LOG_ERROR')
+    xray_recorder.configure(sampling=False)
     value = 1
 
     @xray_recorder.capture()


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* To maintain consistency across SDKs and to prevent malformed trace headers from breaking services, this PR sets the default context missing strategy to `'LOG_ERROR'` instead of `'RUNTIME_ERROR'`.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
