### PR TITLE
Fix tox version in CI

### DIFF
--- a/.github/workflows/UnitTesting.yaml
+++ b/.github/workflows/UnitTesting.yaml
@@ -36,7 +36,7 @@ jobs:
           python-version: ${{ env[matrix.python-version] }}
 
       - name: Install tox
-        run: pip install tox==3.27.1 -U tox-factor
+        run: pip install "tox<=3.27.1" -U tox-factor
 
       - name: Cache tox environment
         # Preserves .tox directory between runs for faster installs

--- a/.github/workflows/UnitTesting.yaml
+++ b/.github/workflows/UnitTesting.yaml
@@ -36,7 +36,7 @@ jobs:
           python-version: ${{ env[matrix.python-version] }}
 
       - name: Install tox
-        run: pip install -U tox-factor
+        run: pip install tox==3.27.1 -U tox-factor
 
       - name: Cache tox environment
         # Preserves .tox directory between runs for faster installs


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Unit Test CI started failing due to an incompatibility between `tox-factor` v0.1.2 and the newly released version of `tox` v4.0. Similar to [changes made in opentelemetry-python](https://github.com/open-telemetry/opentelemetry-python/pull/3081). 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
