### PR TITLE
Fix pynamodb tests for Python < 3.6

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -104,7 +104,9 @@ deps =
     ext-django-4: Django >=4.0,<5.0
     ext-django: django-fake-model
 
-    ext-pynamodb: pynamodb >= 3.3.1
+    py{27,34,35}-ext-pynamodb: pynamodb >=3.3.1,<4.4
+    py{27,34,35}-ext-pynamodb: botocore <1.28
+    py{36,37,38,39}-ext-pynamodb: pynamodb >=3.3.1
 
     ext-psycopg2: psycopg2
     ext-psycopg2: testing.postgresql


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:* Add upper bound `<4.4` to pynamodb for tests running on Python 2.7 to 3.5.

PynamoDB 4.4.0 introduced syntax that's only valid on Python >= 3.6 while still claiming to support Python < 3.6. (To be fair, Python < 3.6 is EOL.)
See pynamodb/PynamoDB#1130

----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
