### PR TITLE
Run tests against Python 3.10 and 3.11

### DIFF
--- a/.github/workflows/UnitTesting.yaml
+++ b/.github/workflows/UnitTesting.yaml
@@ -21,10 +21,12 @@ jobs:
       py37: 3.7
       py38: 3.8
       py39: 3.9
+      py310: '3.10'
+      py311: '3.11'
     strategy:
       fail-fast: false
       matrix:
-        python-version: [py27, py34, py35, py36, py37, py38, py39]
+        python-version: [py27, py34, py35, py36, py37, py38, py39, py310, py311]
         testenv: [core, ext]
     steps:
       - name: Checkout repo

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,8 @@ setup(
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
     ],
 
     install_requires=[

--- a/tox.ini
+++ b/tox.ini
@@ -1,50 +1,50 @@
 [tox]
 skip_missing_interpreters = True
 envlist =
-    py{27,34,35,36,37,38,39}-core
+    py{27,34,35,36,37,38,39,310,311}-core
 
     ; Unavailable for python 2.7 & 3.4
-    py{35,36,37,38,39}-ext-aiobotocore
+    py{35,36,37,38,39,310,311}-ext-aiobotocore
 
     ; Unavailable for python 2.7 & 3.4
-    py{35,36,37,38,39}-ext-aiohttp
+    py{35,36,37,38,39,310,311}-ext-aiohttp
 
-    py{27,34,35,36,37,38,39}-ext-botocore
+    py{27,34,35,36,37,38,39,310,311}-ext-botocore
 
-    py{27,34,35,36,37,38,39}-ext-bottle
+    py{27,34,35,36,37,38,39,310,311}-ext-bottle
 
     ; Django2 (2.2+) is only for python 3.5 +
     py{35,36,37,38,39}-ext-django-2
 
     ; Django3 is only for python 3.6+
-    py{36,37,38,39}-ext-django-3
+    py{36,37,38,39,310}-ext-django-3
 
     ; Django4 is only for python 3.8+
-    py{38,39}-ext-django-4
+    py{38,39,310,311}-ext-django-4
 
-    py{27,34,35,36,37,38,39}-ext-flask
+    py{27,34,35,36,37,38,39,310,311}-ext-flask
 
-    py{27,34,35,36,37,38,39}-ext-flask_sqlalchemy
+    py{27,34,35,36,37,38,39,310,311}-ext-flask_sqlalchemy
 
-    py{27,34,35,36,37,38,39}-ext-httplib
+    py{27,34,35,36,37,38,39,310,311}-ext-httplib
 
-    py{37,38,39}-ext-httpx
+    py{37,38,39,310,311}-ext-httpx
 
-    py{27,34,35,36,37,38,39}-ext-pg8000
+    py{27,34,35,36,37,38,39,310,311}-ext-pg8000
 
-    py{27,34,35,36,37,38,39}-ext-psycopg2
+    py{27,34,35,36,37,38,39,310,311}-ext-psycopg2
 
-    py{27,34,35,36,37,38,39}-ext-pymysql
+    py{27,34,35,36,37,38,39,310,311}-ext-pymysql
 
-    py{27,34,35,36,37,38,39}-ext-pynamodb
+    py{27,34,35,36,37,38,39,310,311}-ext-pynamodb
 
-    py{27,34,35,36,37,38,39}-ext-requests
+    py{27,34,35,36,37,38,39,310,311}-ext-requests
 
-    py{27,34,35,36,37,38,39}-ext-sqlalchemy
+    py{27,34,35,36,37,38,39,310,311}-ext-sqlalchemy
 
-    py{27,34,35,36,37,38,39}-ext-sqlalchemy_core
+    py{27,34,35,36,37,38,39,310,311}-ext-sqlalchemy_core
 
-    py{27,34,35,36,37,38,39}-ext-sqlite3
+    py{27,34,35,36,37,38,39,310,311}-ext-sqlite3
 
 [testenv]
 passenv = TOXENV CI CODECOV_*
@@ -68,7 +68,7 @@ deps =
     py34: typing >= 3.7.4.3
 
     ; Python 3.5+ only deps
-    py{35,36,37,38,39}: pytest-asyncio
+    py{35,36,37,38,39,310,311}: pytest-asyncio
 
     ext-aiobotocore: aiobotocore >= 0.10.0
     ext-aiobotocore: pytest-asyncio
@@ -102,7 +102,7 @@ deps =
 
     py{27,34,35}-ext-pynamodb: pynamodb >=3.3.1,<4.4
     py{27,34,35}-ext-pynamodb: botocore <1.28
-    py{36,37,38,39}-ext-pynamodb: pynamodb >=3.3.1
+    py{36,37,38,39,310,311}-ext-pynamodb: pynamodb >=3.3.1
 
     ext-psycopg2: psycopg2
     ext-psycopg2: testing.postgresql
@@ -112,7 +112,7 @@ deps =
 
     ext-pymysql: testing.mysqld
     py{27,34,35}-ext-pymysql: pymysql < 1.0.0
-    py{36,37,38,39}-ext-pymysql: pymysql >= 1.0.0
+    py{36,37,38,39,310,311}-ext-pymysql: pymysql >= 1.0.0
 
 setenv =
     DJANGO_SETTINGS_MODULE = tests.ext.django.app.settings
@@ -124,7 +124,7 @@ commands =
 
     ; Async methods are only available for python 3.5+
     py{27,34}-core: coverage run --append --source aws_xray_sdk -m pytest --ignore tests/ext --ignore tests/test_async_local_storage.py --ignore tests/test_async_recorder.py
-    py{35,36,37,38,39}-core: coverage run --append --source aws_xray_sdk -m pytest --ignore tests/ext
+    py{35,36,37,38,39,310,311}-core: coverage run --append --source aws_xray_sdk -m pytest --ignore tests/ext
 
     ext-aiobotocore: coverage run --append --source aws_xray_sdk -m pytest tests/ext/aiobotocore
 
@@ -157,7 +157,7 @@ commands =
     ext-sqlalchemy: coverage run --append --source aws_xray_sdk -m pytest tests/ext/sqlalchemy
 
     ; sqlalchemy_core - 2.0 style execution is not supported for python 3.4 & 3.5
-    py{27,36,37,38,39}-ext-sqlalchemy_core: coverage run --append --source aws_xray_sdk -m pytest tests/ext/sqlalchemy_core
+    py{27,36,37,38,39,310,311}-ext-sqlalchemy_core: coverage run --append --source aws_xray_sdk -m pytest tests/ext/sqlalchemy_core
     py{34,35}-ext-sqlalchemy_core: coverage run --append --source aws_xray_sdk -m pytest tests/ext/sqlalchemy_core --ignore tests/ext/sqlalchemy_core/test_sqlalchemy_core_2.py
 
     ext-sqlite3: coverage run --append --source aws_xray_sdk -m pytest tests/ext/sqlite3


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:* Run tests against Python 3.10 and 3.11.  Also add trove classifiers.

----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
