### PR TITLE
version pinning sqlalchemy to 1.x to fix CI

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -88,10 +88,11 @@ deps =
 
     ext-flask_sqlalchemy: flask >= 0.10
     ext-flask_sqlalchemy: Flask-SQLAlchemy <= 2.5.1
+    ext-flask_sqlalchemy: sqlalchemy >=1.0.0,<2.0.0
 
-    ext-sqlalchemy: sqlalchemy
+    ext-sqlalchemy: sqlalchemy >=1.0.0,<2.0.0
 
-    ext-sqlalchemy_core: sqlalchemy
+    ext-sqlalchemy_core: sqlalchemy >=1.0.0,<2.0.0
     ext-sqlalchemy_core: testing.postgresql
     ext-sqlalchemy_core: psycopg2
 


### PR DESCRIPTION
*Issue #, if available:*
Follow up from https://github.com/aws/aws-xray-sdk-python/pull/376#issuecomment-1408035455

*Description of changes:*
Pinning the sqlalchemy dependency to < 2.0.0 since there are breaking changes in the new major version, rendering it incompatible with the X-Ray SDK.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
