### PR TITLE
Bump unbuntu image to 20.04, remove python 2.7, 3.4, 3.5, 3.6 from unit test

### DIFF
--- a/.github/workflows/UnitTesting.yaml
+++ b/.github/workflows/UnitTesting.yaml
@@ -43,7 +43,9 @@ jobs:
           key: tox-cache-${{ matrix.python-version }}-${{ matrix.testenv }}-${{ hashFiles('tox.ini') }}
     
       - name: Start MySQL service
+        if: ${{ matrix.testenv == 'ext' }}
         run: |
+          sudo apt-get install mysql-client
           sudo /etc/init.d/mysql start
 
       - name: Run tox

--- a/.github/workflows/UnitTesting.yaml
+++ b/.github/workflows/UnitTesting.yaml
@@ -12,7 +12,7 @@ jobs:
     # "setup-python" action doesn't provide python 3.4 binaries for ubuntu-latest.
     # Sticking to Ubuntu 18.04 as recommended here:
     # https://github.com/actions/setup-python/issues/185#issuecomment-768232756
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     env:
       py27: 2.7
       py34: 3.4

--- a/.github/workflows/UnitTesting.yaml
+++ b/.github/workflows/UnitTesting.yaml
@@ -9,10 +9,7 @@ on:
 
 jobs:
   test:
-    # "setup-python" action doesn't provide python 3.4 binaries for ubuntu-latest.
-    # Sticking to Ubuntu 18.04 as recommended here:
-    # https://github.com/actions/setup-python/issues/185#issuecomment-768232756
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     env:
       py27: 2.7
       py34: 3.4

--- a/.github/workflows/UnitTesting.yaml
+++ b/.github/workflows/UnitTesting.yaml
@@ -46,6 +46,7 @@ jobs:
         if: ${{ matrix.testenv == 'ext' }}
         run: |
           sudo apt-get install mysql-client
+          sudo apt install mysql-server
           sudo /etc/init.d/mysql start
 
       - name: Run tox

--- a/.github/workflows/UnitTesting.yaml
+++ b/.github/workflows/UnitTesting.yaml
@@ -12,7 +12,7 @@ jobs:
     # "setup-python" action doesn't provide python 3.4 binaries for ubuntu-latest.
     # Sticking to Ubuntu 18.04 as recommended here:
     # https://github.com/actions/setup-python/issues/185#issuecomment-768232756
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     env:
       py27: 2.7
       py34: 3.4

--- a/.github/workflows/UnitTesting.yaml
+++ b/.github/workflows/UnitTesting.yaml
@@ -43,7 +43,6 @@ jobs:
           key: tox-cache-${{ matrix.python-version }}-${{ matrix.testenv }}-${{ hashFiles('tox.ini') }}
     
       - name: Start MySQL service
-        if: ${{ matrix.testenv.ext }} 
         run: |
           sudo /etc/init.d/mysql start
 

--- a/.github/workflows/UnitTesting.yaml
+++ b/.github/workflows/UnitTesting.yaml
@@ -11,10 +11,6 @@ jobs:
   test:
     runs-on: ubuntu-20.04
     env:
-      py27: 2.7
-      py34: 3.4
-      py35: 3.5
-      py36: 3.6
       py37: 3.7
       py38: 3.8
       py39: 3.9

--- a/.github/workflows/UnitTesting.yaml
+++ b/.github/workflows/UnitTesting.yaml
@@ -12,7 +12,7 @@ jobs:
     # "setup-python" action doesn't provide python 3.4 binaries for ubuntu-latest.
     # Sticking to Ubuntu 18.04 as recommended here:
     # https://github.com/actions/setup-python/issues/185#issuecomment-768232756
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     env:
       py27: 2.7
       py34: 3.4

--- a/.github/workflows/UnitTesting.yaml
+++ b/.github/workflows/UnitTesting.yaml
@@ -42,12 +42,12 @@ jobs:
             ~/.cache/pip
           key: tox-cache-${{ matrix.python-version }}-${{ matrix.testenv }}-${{ hashFiles('tox.ini') }}
     
-      - name: Start MySQL service
-        if: ${{ matrix.testenv == 'ext' }}
-        run: |
-          sudo apt-get install mysql-client
-          sudo apt install mysql-server
-          sudo /etc/init.d/mysql start
+#       - name: Start MySQL service
+#         if: ${{ matrix.testenv == 'ext' }}
+#         run: |
+#           sudo apt-get install mysql-client
+#           sudo apt install mysql-server
+#           sudo /etc/init.d/mysql start
 
       - name: Run tox
         run: |

--- a/.github/workflows/UnitTesting.yaml
+++ b/.github/workflows/UnitTesting.yaml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [py27, py34, py35, py36, py37, py38, py39, py310, py311]
+        python-version: [py37, py38, py39, py310, py311]
         testenv: [core, ext]
     steps:
       - name: Checkout repo
@@ -41,6 +41,11 @@ jobs:
             .tox
             ~/.cache/pip
           key: tox-cache-${{ matrix.python-version }}-${{ matrix.testenv }}-${{ hashFiles('tox.ini') }}
+    
+      - name: Start MySQL service
+        if: ${{ matrix.testenv.ext }} 
+        run: |
+          sudo /etc/init.d/mysql start
 
       - name: Run tox
         run: |


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/actions/runner-images/issues/6002
*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
