### PR TITLE
Start MySQL from GH actions, upgrade ubuntu, and remove python versions for tests

### DIFF
--- a/.github/workflows/UnitTesting.yaml
+++ b/.github/workflows/UnitTesting.yaml
@@ -9,28 +9,29 @@ on:
 
 jobs:
   test:
-    # "setup-python" action doesn't provide python 3.4 binaries for ubuntu-latest.
-    # Sticking to Ubuntu 18.04 as recommended here:
-    # https://github.com/actions/setup-python/issues/185#issuecomment-768232756
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     env:
-      py27: 2.7
-      py34: 3.4
-      py35: 3.5
-      py36: 3.6
       py37: 3.7
       py38: 3.8
       py39: 3.9
       py310: '3.10'
       py311: '3.11'
+      DB_DATABASE: test_db
+      DB_USER: root
+      DB_PASSWORD: root
     strategy:
       fail-fast: false
       matrix:
-        python-version: [py27, py34, py35, py36, py37, py38, py39, py310, py311]
+        python-version: [py37, py38, py39, py310, py311]
         testenv: [core, ext]
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3
+
+      - name: Start MySQL
+        run: |
+          sudo /etc/init.d/mysql start
+          mysql -e 'CREATE DATABASE ${{ env.DB_DATABASE }};' -u${{ env.DB_USER }} -p${{ env.DB_PASSWORD }}
 
       - name: Setup Python
         uses: actions/setup-python@v4

--- a/.github/workflows/UnitTesting.yaml
+++ b/.github/workflows/UnitTesting.yaml
@@ -29,6 +29,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Start MySQL
+        if: ${{ matrix.testenv == 'ext' }}
         run: |
           sudo /etc/init.d/mysql start
           mysql -e 'CREATE DATABASE ${{ env.DB_DATABASE }};' -u${{ env.DB_USER }} -p${{ env.DB_PASSWORD }}

--- a/README.md
+++ b/README.md
@@ -7,13 +7,17 @@ AWS X-Ray supports using OpenTelemetry Python and the AWS Distro for OpenTelemet
 
 If you want additional features when tracing your Python applications, please [open an issue on the OpenTelemetry Python Instrumentation repository](https://github.com/open-telemetry/opentelemetry-python-contrib/issues/new?labels=feature-request&template=feature_request.md&title=X-Ray%20Compatible%20Feature%20Request).
 
+### :mega: Python Versions End-of-Support Notice
+
+AWS X-Ray SDK for Python versions `>2.11.0` has dropped support for Python 2.7, 3.4, 3.5, and 3.6.
+
 # AWS X-Ray SDK for Python
 
 ![Screenshot of the AWS X-Ray console](/images/example_servicemap.png?raw=true)
 
 ## Installing
 
-The AWS X-Ray SDK for Python is compatible with Python 2.7, 3.4, 3.5, 3.6, 3.7, 3.8, and 3.9.
+The AWS X-Ray SDK for Python is compatible with Python 3.7, 3.8, 3.9, 3.10, and 3.11.
 
 Install the SDK using the following command (the SDK's non-testing dependencies will be installed).
 

--- a/tox.ini
+++ b/tox.ini
@@ -97,7 +97,6 @@ deps =
     ext-pg8000: pg8000 <= 1.20.0
     ext-pg8000: testing.postgresql
 
-    ext-pymysql: testing.mysqld
     py{37,38,39,310,311}-ext-pymysql: pymysql >= 1.0.0
 
 setenv =

--- a/tox.ini
+++ b/tox.ini
@@ -1,50 +1,46 @@
 [tox]
 skip_missing_interpreters = True
 envlist =
-    py{27,34,35,36,37,38,39,310,311}-core
+    py{37,38,39,310,311}-core
 
-    ; Unavailable for python 2.7 & 3.4
-    py{35,36,37,38,39,310,311}-ext-aiobotocore
+    py{37,38,39,310,311}-ext-aiobotocore
 
-    ; Unavailable for python 2.7 & 3.4
-    py{35,36,37,38,39,310,311}-ext-aiohttp
+    py{37,38,39,310,311}-ext-aiohttp
 
-    py{27,34,35,36,37,38,39,310,311}-ext-botocore
+    py{37,38,39,310,311}-ext-botocore
 
-    py{27,34,35,36,37,38,39,310,311}-ext-bottle
+    py{37,38,39,310,311}-ext-bottle
 
-    ; Django2 (2.2+) is only for python 3.5 +
-    py{35,36,37,38,39}-ext-django-2
+    py{37,38,39}-ext-django-2
 
-    ; Django3 is only for python 3.6+
-    py{36,37,38,39,310}-ext-django-3
+    py{37,38,39,310}-ext-django-3
 
     ; Django4 is only for python 3.8+
     py{38,39,310,311}-ext-django-4
 
-    py{27,34,35,36,37,38,39,310,311}-ext-flask
+    py{37,38,39,310,311}-ext-flask
 
-    py{27,34,35,36,37,38,39,310,311}-ext-flask_sqlalchemy
+    py{37,38,39,310,311}-ext-flask_sqlalchemy
 
-    py{27,34,35,36,37,38,39,310,311}-ext-httplib
+    py{37,38,39,310,311}-ext-httplib
 
     py{37,38,39,310,311}-ext-httpx
 
-    py{27,34,35,36,37,38,39,310,311}-ext-pg8000
+    py{37,38,39,310,311}-ext-pg8000
 
-    py{27,34,35,36,37,38,39,310,311}-ext-psycopg2
+    py{37,38,39,310,311}-ext-psycopg2
 
-    py{27,34,35,36,37,38,39,310,311}-ext-pymysql
+    py{37,38,39,310,311}-ext-pymysql
 
-    py{27,34,35,36,37,38,39,310,311}-ext-pynamodb
+    py{37,38,39,310,311}-ext-pynamodb
 
-    py{27,34,35,36,37,38,39,310,311}-ext-requests
+    py{37,38,39,310,311}-ext-requests
 
-    py{27,34,35,36,37,38,39,310,311}-ext-sqlalchemy
+    py{37,38,39,310,311}-ext-sqlalchemy
 
-    py{27,34,35,36,37,38,39,310,311}-ext-sqlalchemy_core
+    py{37,38,39,310,311}-ext-sqlalchemy_core
 
-    py{27,34,35,36,37,38,39,310,311}-ext-sqlite3
+    py{37,38,39,310,311}-ext-sqlite3
 
 [testenv]
 passenv = TOXENV CI CODECOV_*
@@ -59,16 +55,8 @@ deps =
     ; Packages common to all test environments
     wrapt
 
-    ; Python 2.7 only deps
-    py{27}: enum34
-    py{27}: mock
-    py{27}: future
-
-    ; Python 3.4 only deps
-    py34: typing >= 3.7.4.3
-
     ; Python 3.5+ only deps
-    py{35,36,37,38,39,310,311}: pytest-asyncio
+    py{37,38,39,310,311}: pytest-asyncio
 
     ext-aiobotocore: aiobotocore >= 0.10.0
     ext-aiobotocore: pytest-asyncio
@@ -101,9 +89,7 @@ deps =
     ext-django-4: Django >=4.0,<5.0
     ext-django: django-fake-model
 
-    py{27,34,35}-ext-pynamodb: pynamodb >=3.3.1,<4.4
-    py{27,34,35}-ext-pynamodb: botocore <1.28
-    py{36,37,38,39,310,311}-ext-pynamodb: pynamodb >=3.3.1
+    py{37,38,39,310,311}-ext-pynamodb: pynamodb >=3.3.1
 
     ext-psycopg2: psycopg2
     ext-psycopg2: testing.postgresql
@@ -112,8 +98,7 @@ deps =
     ext-pg8000: testing.postgresql
 
     ext-pymysql: testing.mysqld
-    py{27,34,35}-ext-pymysql: pymysql < 1.0.0
-    py{36,37,38,39,310,311}-ext-pymysql: pymysql >= 1.0.0
+    py{37,38,39,310,311}-ext-pymysql: pymysql >= 1.0.0
 
 setenv =
     DJANGO_SETTINGS_MODULE = tests.ext.django.app.settings
@@ -123,9 +108,7 @@ setenv =
 commands =
     coverage erase
 
-    ; Async methods are only available for python 3.5+
-    py{27,34}-core: coverage run --append --source aws_xray_sdk -m pytest --ignore tests/ext --ignore tests/test_async_local_storage.py --ignore tests/test_async_recorder.py
-    py{35,36,37,38,39,310,311}-core: coverage run --append --source aws_xray_sdk -m pytest --ignore tests/ext
+    py{37,38,39,310,311}-core: coverage run --append --source aws_xray_sdk -m pytest --ignore tests/ext
 
     ext-aiobotocore: coverage run --append --source aws_xray_sdk -m pytest tests/ext/aiobotocore
 
@@ -157,9 +140,7 @@ commands =
 
     ext-sqlalchemy: coverage run --append --source aws_xray_sdk -m pytest tests/ext/sqlalchemy
 
-    ; sqlalchemy_core - 2.0 style execution is not supported for python 3.4 & 3.5
-    py{27,36,37,38,39,310,311}-ext-sqlalchemy_core: coverage run --append --source aws_xray_sdk -m pytest tests/ext/sqlalchemy_core
-    py{34,35}-ext-sqlalchemy_core: coverage run --append --source aws_xray_sdk -m pytest tests/ext/sqlalchemy_core --ignore tests/ext/sqlalchemy_core/test_sqlalchemy_core_2.py
+    py{37,38,39,310,311}-ext-sqlalchemy_core: coverage run --append --source aws_xray_sdk -m pytest tests/ext/sqlalchemy_core
 
     ext-sqlite3: coverage run --append --source aws_xray_sdk -m pytest tests/ext/sqlite3
 


### PR DESCRIPTION
*Issue #, if available:*
Ubuntu 18.04 deprecation:
https://github.com/actions/runner-images/issues/6002
Also, the latest Ubuntu image uses MySQL 8, which breaks the `testing.mysqld` dependency as it uses `mysql_install_db` which is removed from MySQL 8.

*Description of changes:*
- Bump unbuntu image to 22.04, remove python 2.7, 3.4, 3.5, 3.6 from unit test
- Start MySQL from GH actions instead of relying on `testing.mysqld` dependency

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
