### PR TITLE
Support passing pytest arguments via tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -107,41 +107,41 @@ setenv =
 commands =
     coverage erase
 
-    py{37,38,39,310,311}-core: coverage run --append --source aws_xray_sdk -m pytest --ignore tests/ext
+    py{37,38,39,310,311}-core: coverage run --append --source aws_xray_sdk -m pytest --ignore tests/ext {posargs}
 
-    ext-aiobotocore: coverage run --append --source aws_xray_sdk -m pytest tests/ext/aiobotocore
+    ext-aiobotocore: coverage run --append --source aws_xray_sdk -m pytest tests/ext/aiobotocore {posargs}
 
-    ext-aiohttp: coverage run --append --source aws_xray_sdk -m pytest tests/ext/aiohttp
+    ext-aiohttp: coverage run --append --source aws_xray_sdk -m pytest tests/ext/aiohttp {posargs}
 
-    ext-botocore: coverage run --append --source aws_xray_sdk -m pytest tests/ext/botocore
+    ext-botocore: coverage run --append --source aws_xray_sdk -m pytest tests/ext/botocore {posargs}
 
-    ext-bottle: coverage run --append --source aws_xray_sdk -m pytest tests/ext/bottle
+    ext-bottle: coverage run --append --source aws_xray_sdk -m pytest tests/ext/bottle {posargs}
 
-    ext-django: coverage run --append --source aws_xray_sdk -m pytest tests/ext/django
+    ext-django: coverage run --append --source aws_xray_sdk -m pytest tests/ext/django {posargs}
 
-    ext-flask: coverage run --append --source aws_xray_sdk -m pytest tests/ext/flask
+    ext-flask: coverage run --append --source aws_xray_sdk -m pytest tests/ext/flask {posargs}
 
-    ext-flask_sqlalchemy: coverage run --append --source aws_xray_sdk -m pytest tests/ext/flask_sqlalchemy
+    ext-flask_sqlalchemy: coverage run --append --source aws_xray_sdk -m pytest tests/ext/flask_sqlalchemy {posargs}
 
-    ext-httplib: coverage run --append --source aws_xray_sdk -m pytest tests/ext/httplib
+    ext-httplib: coverage run --append --source aws_xray_sdk -m pytest tests/ext/httplib {posargs}
 
-    ext-httpx: coverage run --append --source aws_xray_sdk -m pytest tests/ext/httpx
+    ext-httpx: coverage run --append --source aws_xray_sdk -m pytest tests/ext/httpx {posargs}
 
-    ext-pg8000: coverage run --append --source aws_xray_sdk -m pytest tests/ext/pg8000
+    ext-pg8000: coverage run --append --source aws_xray_sdk -m pytest tests/ext/pg8000 {posargs}
 
-    ext-psycopg2: coverage run --append --source aws_xray_sdk -m pytest tests/ext/psycopg2
+    ext-psycopg2: coverage run --append --source aws_xray_sdk -m pytest tests/ext/psycopg2 {posargs}
 
-    ext-pymysql: coverage run --append --source aws_xray_sdk -m pytest tests/ext/pymysql
+    ext-pymysql: coverage run --append --source aws_xray_sdk -m pytest tests/ext/pymysql {posargs}
 
-    ext-pynamodb: coverage run --append --source aws_xray_sdk -m pytest tests/ext/pynamodb
+    ext-pynamodb: coverage run --append --source aws_xray_sdk -m pytest tests/ext/pynamodb {posargs}
 
-    ext-requests: coverage run --append --source aws_xray_sdk -m pytest tests/ext/requests
+    ext-requests: coverage run --append --source aws_xray_sdk -m pytest tests/ext/requests {posargs}
 
-    ext-sqlalchemy: coverage run --append --source aws_xray_sdk -m pytest tests/ext/sqlalchemy
+    ext-sqlalchemy: coverage run --append --source aws_xray_sdk -m pytest tests/ext/sqlalchemy {posargs}
 
-    py{37,38,39,310,311}-ext-sqlalchemy_core: coverage run --append --source aws_xray_sdk -m pytest tests/ext/sqlalchemy_core
+    py{37,38,39,310,311}-ext-sqlalchemy_core: coverage run --append --source aws_xray_sdk -m pytest tests/ext/sqlalchemy_core {posargs}
 
-    ext-sqlite3: coverage run --append --source aws_xray_sdk -m pytest tests/ext/sqlite3
+    ext-sqlite3: coverage run --append --source aws_xray_sdk -m pytest tests/ext/sqlite3 {posargs}
 
     ; TODO: add additional logic to combine coverage from "core" and "ext" test runs
     ; codecov


### PR DESCRIPTION
This could be used, for example, to increase verbosity or to skip particular tests.

*Issue #, if available:* (no issue filed)

*Description of changes:*

Adds `{posargs}` to the end of each `pytest` invocation in `tox.ini`.

Sample usage: `$ tox -e py311-core -- -v`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
