### PR TITLE
Disable IMDSv1 from Elastic Beanstalk

### DIFF
--- a/terraform/eb.tf
+++ b/terraform/eb.tf
@@ -71,4 +71,10 @@ resource "aws_elastic_beanstalk_environment" "eb_env" {
     name = "XRayEnabled"
     value = "true"
   }
+  
+  setting {
+    namespace = "aws:autoscaling:launchconfiguration"
+    name = "DisableIMDSv1"
+    value = "true"
+  }
 }


### PR DESCRIPTION
Integration workflow verify the functionality in AWS Elastic Beanstalk. For AWS security reason we need to disable IMDSv1 from EB environment.

*Issue #, if available:*

*Description of changes:*
<img width="885" alt="Screenshot 2023-04-26 at 5 10 47 PM" src="https://user-images.githubusercontent.com/66336933/234728268-f1a46b0b-efed-461e-b665-7253ae9d8899.png">


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
