### PR TITLE
[Documentation] Improve API reference for patch and patch_all

### DIFF
--- a/aws_xray_sdk/core/patcher.py
+++ b/aws_xray_sdk/core/patcher.py
@@ -47,6 +47,18 @@ _PATCHED_MODULES = set()
 
 
 def patch_all(double_patch=False):
+    """
+    The X-Ray Python SDK supports patching aioboto3, aiobotocore, boto3, botocore, pynamodb, requests, 
+    sqlite3, mysql, httplib, pymongo, pymysql, psycopg2, pg8000, sqlalchemy_core, httpx, and mysql-connector.
+
+    To patch all supported libraries::
+
+        from aws_xray_sdk.core import patch_all
+
+        patch_all()
+
+    :param bool double_patch: enable or disable patching of indirect dependencies.
+    """
     if double_patch:
         patch(SUPPORTED_MODULES, raise_errors=False)
     else:
@@ -66,6 +78,16 @@ def _is_valid_import(module):
 
 
 def patch(modules_to_patch, raise_errors=True, ignore_module_patterns=None):
+    """
+    To patch specific modules::
+
+        from aws_xray_sdk.core import patch
+
+        i_want_to_patch = ('botocore') # a tuple that contains the libs you want to patch
+        patch(i_want_to_patch)
+
+    :param tuple modules_to_patch: a tuple containing the list of libraries to be patched
+    """
     enabled = global_sdk_config.sdk_enabled()
     if not enabled:
         log.debug("Skipped patching modules %s because the SDK is currently disabled." % ', '.join(modules_to_patch))

--- a/aws_xray_sdk/core/recorder.py
+++ b/aws_xray_sdk/core/recorder.py
@@ -88,6 +88,7 @@ class AWSXRayRecorder:
 
         Configure needs to run before patching thrid party libraries
         to avoid creating dangling subsegment.
+
         :param bool sampling: If sampling is enabled, every time the recorder
             creates a segment it decides whether to send this segment to
             the X-Ray daemon. This setting is not used if the recorder

--- a/docs/aws_xray_sdk.ext.httpx.rst
+++ b/docs/aws_xray_sdk.ext.httpx.rst
@@ -1,0 +1,21 @@
+aws\_xray\_sdk.ext.httpx package
+================================
+
+Submodules
+----------
+
+aws\_xray\_sdk.ext.httpx.patch module
+-------------------------------------
+
+.. automodule:: aws_xray_sdk.ext.httpx.patch
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: aws_xray_sdk.ext.httpx
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/aws_xray_sdk.ext.pg8000.rst
+++ b/docs/aws_xray_sdk.ext.pg8000.rst
@@ -1,0 +1,21 @@
+aws\_xray\_sdk.ext.pg8000 package
+=================================
+
+Submodules
+----------
+
+aws\_xray\_sdk.ext.pg8000.patch module
+--------------------------------------
+
+.. automodule:: aws_xray_sdk.ext.pg8000.patch
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: aws_xray_sdk.ext.pg8000
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/aws_xray_sdk.ext.psycopg2.rst
+++ b/docs/aws_xray_sdk.ext.psycopg2.rst
@@ -1,0 +1,21 @@
+aws\_xray\_sdk.ext.psycopg2 package
+===================================
+
+Submodules
+----------
+
+aws\_xray\_sdk.ext.psycopg2.patch module
+----------------------------------------
+
+.. automodule:: aws_xray_sdk.ext.psycopg2.patch
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: aws_xray_sdk.ext.psycopg2
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/aws_xray_sdk.ext.pymongo.rst
+++ b/docs/aws_xray_sdk.ext.pymongo.rst
@@ -1,0 +1,21 @@
+aws\_xray\_sdk.ext.pymongo package
+==================================
+
+Submodules
+----------
+
+aws\_xray\_sdk.ext.pymongo.patch module
+---------------------------------------
+
+.. automodule:: aws_xray_sdk.ext.pymongo.patch
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: aws_xray_sdk.ext.pymongo
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/aws_xray_sdk.ext.pymysql.rst
+++ b/docs/aws_xray_sdk.ext.pymysql.rst
@@ -1,0 +1,21 @@
+aws\_xray\_sdk.ext.pymysql package
+==================================
+
+Submodules
+----------
+
+aws\_xray\_sdk.ext.pymysql.patch module
+---------------------------------------
+
+.. automodule:: aws_xray_sdk.ext.pymysql.patch
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: aws_xray_sdk.ext.pymysql
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/aws_xray_sdk.ext.sqlalchemy_core.rst
+++ b/docs/aws_xray_sdk.ext.sqlalchemy_core.rst
@@ -1,0 +1,21 @@
+aws\_xray\_sdk.ext.sqlalchemy\_core package
+===========================================
+
+Submodules
+----------
+
+aws\_xray\_sdk.ext.sqlalchemy\_core.patch module
+------------------------------------------------
+
+.. automodule:: aws_xray_sdk.ext.sqlalchemy_core.patch
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: aws_xray_sdk.ext.sqlalchemy_core
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/thirdparty.rst
+++ b/docs/thirdparty.rst
@@ -6,8 +6,8 @@ Third Party Library Support
 Patching Supported Libraries
 ----------------------------
 
-The SDK supports aioboto3, aiobotocore, boto3, botocore, pynamodb, requests, sqlite3, httplib and
-mysql-connector.
+The X-Ray Python SDK supports patching aioboto3, aiobotocore, boto3, botocore, pynamodb, requests, 
+sqlite3, mysql, httplib, pymongo, pymysql, psycopg2, pg8000, sqlalchemy_core, httpx, and mysql-connector.
 
 To patch, use code like the following in the main app::
 
@@ -36,6 +36,12 @@ The following modules are availble to patch::
         'sqlite3',
         'mysql',
         'httplib',
+        'pymongo',
+        'pymysql',
+        'psycopg2',
+        'pg8000',
+        'sqlalchemy_core',
+        'httpx',
     )
 
 Patching boto3 and botocore are equivalent since boto3 depends on botocore.


### PR DESCRIPTION
*Issue #, if available:* #403

*Description of changes:* 

- Added docstrings for `patch` and `patch_all` APIs, which are reflected in the API reference documentation. These additions are consistent with the [third party libraries public documentation](https://docs.aws.amazon.com/xray-sdk-for-python/latest/reference/thirdparty.html#patching-supported-libraries) for these APIs. 
- Updated list of supported modules for patching (`SUPPORTED_MODULES`) to match the [implementation in patcher.py](https://github.com/aws/aws-xray-sdk-python/blob/2976b25750d04ebe6dc7d0a3e399444896e82cae/aws_xray_sdk/core/patcher.py#L15-L29)
    - New documentation pages for these extensions were auto created when generating docs. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
