### PR TITLE
Fix sqlalchemy password leakage

### DIFF
--- a/aws_xray_sdk/ext/sqlalchemy_core/patch.py
+++ b/aws_xray_sdk/ext/sqlalchemy_core/patch.py
@@ -1,4 +1,5 @@
 import logging
+import re
 import sys
 from urllib.parse import urlparse, uses_netloc
 
@@ -14,7 +15,7 @@ from aws_xray_sdk.ext.util import unwrap
 def _sql_meta(engine_instance, args):
     try:
         metadata = {}
-        url = urlparse(engine_instance.engine.render_as_string())
+        url = urlparse(re.match(r"Engine\((.*?)\)", str(engine_instance.engine)).group(1))
         # Add Scheme to uses_netloc or // will be missing from url.
         uses_netloc.append(url.scheme)
         if url.password is None:

--- a/aws_xray_sdk/ext/sqlalchemy_core/patch.py
+++ b/aws_xray_sdk/ext/sqlalchemy_core/patch.py
@@ -14,7 +14,7 @@ from aws_xray_sdk.ext.util import unwrap
 def _sql_meta(engine_instance, args):
     try:
         metadata = {}
-        url = urlparse(str(engine_instance.engine.url))
+        url = urlparse(engine_instance.engine.render_as_string())
         # Add Scheme to uses_netloc or // will be missing from url.
         uses_netloc.append(url.scheme)
         if url.password is None:


### PR DESCRIPTION
*Issue #, if available:*

No issue created.

*Description of changes:*

I attempted to add tests to demonstrate this, but the `testing.postgres` dependency uses the default username without a password in a manner that I couldn't easily override. If you are interested in setting up a reproduction case, use a password that contains the character `#` in it and send the generated sqlalchemy segments to AWS. The name of the segment will include the password in it.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
