### PR TITLE
BugFix: set_trace_entity() in lambda adds segment to thread local

### DIFF
--- a/aws_xray_sdk/core/lambda_launcher.py
+++ b/aws_xray_sdk/core/lambda_launcher.py
@@ -78,6 +78,18 @@ class LambdaContext(Context):
         current_entity.add_subsegment(subsegment)
         self._local.entities.append(subsegment)
 
+    def set_trace_entity(self, trace_entity):
+        """
+        For Lambda context, we additionally store the segment in the thread local.
+        """
+        if self._is_subsegment(trace_entity):
+            segment = trace_entity.parent_segment
+        else:
+            segment = trace_entity
+
+        setattr(self._local, 'segment', segment)
+        setattr(self._local, 'entities', [trace_entity])
+
     def get_trace_entity(self):
         self._refresh_context()
         if getattr(self._local, 'entities', None):

--- a/tests/test_lambda_context.py
+++ b/tests/test_lambda_context.py
@@ -83,3 +83,24 @@ def test_non_initialized():
     temp_context.put_subsegment(subsegment)
 
     assert temp_context.get_trace_entity() == subsegment
+
+
+def test_set_trace_entity():
+    segment = context.get_trace_entity()
+    subsegment = Subsegment('name', 'local', segment)
+
+    context. clear_trace_entities()
+
+    # should set the parent segment in thread local
+    context.set_trace_entity(subsegment)
+    tl = context._local
+    assert tl.__getattribute__('segment') == segment
+    assert context.get_trace_entity() == subsegment
+
+    context.clear_trace_entities()
+
+    # should set the segment in thread local
+    context.set_trace_entity(segment)
+    tl = context._local
+    assert tl.__getattribute__('segment') == segment
+    assert context.get_trace_entity() == segment


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws/aws-xray-sdk-python/issues/388
The overridden [`get_trace_entity()`](https://github.com/aws/aws-xray-sdk-python/blob/d9fec7d9fc88a921ab2fd34982e99fcd963efd75/aws_xray_sdk/core/lambda_launcher.py#L81) method in lambda also [checks the presence of `segment` in the thread local](https://github.com/aws/aws-xray-sdk-python/blob/d9fec7d9fc88a921ab2fd34982e99fcd963efd75/aws_xray_sdk/core/lambda_launcher.py#L100-L109). This check is done to prevent context leakage across invocations. When the trace context is initialized upon lambda function invocation, the `segment` is placed in the main thread's local. But if a child thread is spawned, the thread local state is not inherited, which is expected due to thread local design for isolation. Due to this whenever the `get_trace_entity()` is called (which would be every time a subsegment is to be created), the thread local is reset causing unexpected parenting of subsegments as mentioned in the above issue.

*Description of changes:*
Since we are checking for `segment` when getting the trace entity, we must also set the `segment` when setting an entity by overriding the [`set_trace_entity()`](https://github.com/aws/aws-xray-sdk-python/blob/6a4c9eea19433af4b4a1c69d42af3ff413c7dc5a/aws_xray_sdk/core/context.py#L103) method in lambda context. This will ensure that the `get_trace_entity()` finds the `segment` in the thread local and won't reset the context.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
