### PR TITLE
Pin flask < 3.x for flask sqlalchemy tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -74,7 +74,7 @@ deps =
 
     ext-flask: flask >= 0.10
 
-    ext-flask_sqlalchemy: flask >= 0.10
+    ext-flask_sqlalchemy: flask >= 0.10,<3.0.0
     ext-flask_sqlalchemy: Flask-SQLAlchemy <= 2.5.1
     ext-flask_sqlalchemy: sqlalchemy >=1.0.0,<2.0.0
 


### PR DESCRIPTION
*Issue:*
Flask SqlAlchemy under the hood tries to import '_app_ctx_stack' from Flask but this has been removed in the new flask v3.0.0: https://github.com/pallets/flask/pull/5223

*Description of changes:*
Pinning the flask dependency major version to prevent breaking the unit tests.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
