### PR TITLE
Fix EB platform version for integration test

### DIFF
--- a/terraform/eb.tf
+++ b/terraform/eb.tf
@@ -55,7 +55,7 @@ resource "aws_elastic_beanstalk_application_version" "eb_app_version" {
 resource "aws_elastic_beanstalk_environment" "eb_env" {
   name                = "${var.resource_prefix}-EB-App-Env"
   application         = aws_elastic_beanstalk_application.eb_app.name
-  solution_stack_name = "64bit Amazon Linux 2 v3.5.10 running Python 3.8"
+  solution_stack_name = "64bit Amazon Linux 2 v3.5.12 running Python 3.8"
   tier = "WebServer"
   version_label = aws_elastic_beanstalk_application_version.eb_app_version.name
   cname_prefix = "${var.resource_prefix}-Eb-app-env"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
It fixed following [Integration Testing](https://github.com/aws/aws-xray-sdk-python/actions/workflows/IntegrationTesting.yaml) error by pumping Elastic Beantalk platform version to v3.5.12.

```
│ Error: InvalidParameterValue: No Solution Stack named '64bit Amazon Linux 2 v3.5.10 running Python 3.8' found.
│ 	status code: 400, request id: e2dbd3dd-b930-4432-9c64-8bb5675a3fc1
│ 
│   with aws_elastic_beanstalk_environment.eb_env,
│   on eb.tf line 55, in resource "aws_elastic_beanstalk_environment" "eb_env":
│   55: resource "aws_elastic_beanstalk_environment" "eb_env" {
```
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
