### PR TITLE
Fix end_time param type docstring

### DIFF
--- a/aws_xray_sdk/core/context.py
+++ b/aws_xray_sdk/core/context.py
@@ -44,7 +44,7 @@ class Context:
         """
         End the current active segment.
 
-        :param int end_time: epoch in seconds. If not specified the current
+        :param float end_time: epoch in seconds. If not specified the current
             system time will be used.
         """
         entity = self.get_trace_entity()
@@ -75,7 +75,7 @@ class Context:
         End the current active segment. Return False if there is no
         subsegment to end.
 
-        :param int end_time: epoch in seconds. If not specified the current
+        :param float end_time: epoch in seconds. If not specified the current
             system time will be used.
         """
         subsegment = self.get_trace_entity()

--- a/aws_xray_sdk/core/models/entity.py
+++ b/aws_xray_sdk/core/models/entity.py
@@ -64,7 +64,7 @@ class Entity:
         Close the trace entity by setting `end_time`
         and flip the in progress flag to False.
 
-        :param int end_time: Epoch in seconds. If not specified
+        :param float end_time: Epoch in seconds. If not specified
             current time will be used.
         """
         self._check_ended()

--- a/aws_xray_sdk/core/models/subsegment.py
+++ b/aws_xray_sdk/core/models/subsegment.py
@@ -133,7 +133,7 @@ class Subsegment(Entity):
         and flip the in progress flag to False. Also decrement
         parent segment's ref counter by 1.
 
-        :param int end_time: Epoch in seconds. If not specified
+        :param float end_time: Epoch in seconds. If not specified
             current time will be used.
         """
         super().close(end_time)


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws/aws-xray-sdk-python/issues/424

*Description of changes:*
- Change the incorrect parameter type for `end_time` from `int` to `float`. Note that the [`time.time()`](https://docs.python.org/3/library/time.html#time.time) (used when the end_time input is not provided) itself is a `float` type.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
