### PR TITLE
Update pytest-asyncio to >= 0.21.2

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -56,7 +56,7 @@ deps =
     wrapt
 
     ; Python 3.5+ only deps
-    py{37,38,39,310,311,312}: pytest-asyncio == 0.21.1
+    py{37,38,39,310,311,312}: pytest-asyncio == 0.21.2
 
     ; For pkg_resources
     py{37,38,39,310,311,312}: setuptools


### PR DESCRIPTION
*Issue #, if available:*
Fix broken unit tests:
https://github.com/aws/aws-xray-sdk-python/actions/runs/8974539459/job/24647120712?pr=428
https://github.com/aws/aws-xray-sdk-python/actions/runs/9069153372/job/24918067890?pr=425
https://github.com/aws/aws-xray-sdk-python/actions/runs/9006436662/job/24743977112

*Description of changes:*
- update pytest-asyncio to >= 0.21.2
(Followed guidance in: https://github.com/pytest-dev/pytest/issues/12269)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
