### PR TITLE
[Lambda] Fix logging to only happen inside lambda function

### DIFF
--- a/aws_xray_sdk/core/lambda_launcher.py
+++ b/aws_xray_sdk/core/lambda_launcher.py
@@ -72,7 +72,7 @@ class LambdaContext(Context):
         current_entity = self.get_trace_entity()
 
         if not self._is_subsegment(current_entity) and (getattr(current_entity, 'initializing', None) or isinstance(current_entity, DummySegment)):
-            if global_sdk_config.sdk_enabled():
+            if global_sdk_config.sdk_enabled() and not os.getenv(LAMBDA_TRACE_HEADER_KEY):
                 log.warning("Subsegment %s discarded due to Lambda worker still initializing" % subsegment.name)
             return
 


### PR DESCRIPTION
Through testing, found that the error message comes no matter what if the trace header is incomplete. The expected behaviour is to only see this message if we are inside a lambda function, hence the expectation for the trace header existing in the environment.

*Description of changes:*
- Add condition checking for the lack of a trace header, indicating we are not in a lambda function, to print the error message.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
