### PR TITLE
Fix warning message condition for subsegment ending

### DIFF
--- a/aws_xray_sdk/core/context.py
+++ b/aws_xray_sdk/core/context.py
@@ -78,11 +78,13 @@ class Context:
         :param float end_time: epoch in seconds. If not specified the current
             system time will be used.
         """
-        subsegment = self.get_trace_entity()
-        if self._is_subsegment(subsegment):
-            subsegment.close(end_time)
+        entity = self.get_trace_entity()
+        if self._is_subsegment(entity):
+            entity.close(end_time)
             self._local.entities.pop()
             return True
+        elif isinstance(entity, DummySegment):
+            return False
         else:
             log.warning("No subsegment to end.")
             return False


### PR DESCRIPTION
Currently, logs for lambda look like the following:
```
...
'_AWS_XRAY_DAEMON_PORT': '2000', 'LC_CTYPE': 'C.UTF-8', 'PYTHONPATH': '/var/runtime', '_X_AMZN_TRACE_ID': 'Root=1-66572db3-0f8e31d10b2f289d7faad872;Lineage=0fd2a748:0'})
[WARNING]	2024-05-29T13:29:34.205Z	e983bd69-7edd-4c92-a7f7-d697aef16a54	No subsegment to end.
[WARNING]	2024-05-29T13:29:34.205Z	e983bd69-7edd-4c92-a7f7-d697aef16a54	No subsegment to end.
END RequestId: e983bd69-7edd-4c92-a7f7-d697aef16a54
...
```
We want these `No subsegment to end` messages only to appear if there is no trace entity found at all. Instead, if there is a dummy segment (like in a Lambda Passthrough environment), we should not emit any message.

*Description of changes:*
- Update condition for error message appearance
- Change variable name to make it clear it can be any trace entity, not just a subsegment but also a segment


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
