### PR TITLE
Fix docstring typo about Context class

### DIFF
--- a/aws_xray_sdk/core/context.py
+++ b/aws_xray_sdk/core/context.py
@@ -22,7 +22,7 @@ class Context:
     replace the current stored entities and to clean up the storage.
 
     For any data access or data mutation, if there is no active segment present
-    if will use user-defined behavior to handle such case. By default it throws
+    it will use user-defined behavior to handle such case. By default it throws
     an runtime error.
 
     This data structure is thread-safe.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This pull request corrects a typographical error in the docstring of the `Context` class, ensuring the documentation accurately reflects the intended message.

The current docstring for the `Context` class contains an incorrect repeated "if" which makes the sentence unclear. 

I believe this is a typo, so I have corrected it to:

> For any data access or data mutation, if there is no active segment present
> **it** will use user-defined behavior to handle such case. By default it throws
>  an runtime error.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
