### PR TITLE
Update coverage package to latest version

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -49,7 +49,7 @@ deps =
     ; Testing packages
     pytest > 3.0.0
     pytest-benchmark
-    coverage == 4.5.4
+    coverage == 7.2.7
     codecov
 
     ; Packages common to all test environments


### PR DESCRIPTION
*Issue #, if available:*
Unit tests are failing for python3.11. ([Failed Test](https://github.com/aws/aws-xray-sdk-python/actions/runs/12323312857/job/34398982742?pr=445#step:7:261)). 

*Description of changes:*
Seems to be an issue with the coverage package, updated it to the latest version and ran the tox test locally

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
