### PR TITLE
Adjust intersphinx_mapping for Sphinx 8 compatibility

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -177,4 +177,6 @@ texinfo_documents = [
 
 
 # Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {'https://docs.python.org/': None}
+intersphinx_mapping = {
+    'python': ('https://docs.python.org/', None),
+}


### PR DESCRIPTION
https://www.sphinx-doc.org/en/master/usage/extensions/intersphinx.html#confval-intersphinx_mapping

*Issue #, if available:*

N/A

*Description of changes:*

Changes the structure of `intersphinx_mapping` in `docs/conf.py` for compatibility with Sphinx 8. This is backwards compatible with at least Sphinx 6 and Sphinx 7.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
