### PR TITLE
Update patch.py for requests

### DIFF
--- a/aws_xray_sdk/ext/requests/patch.py
+++ b/aws_xray_sdk/ext/requests/patch.py
@@ -9,7 +9,7 @@ def patch():
 
     wrapt.wrap_function_wrapper(
         'requests',
-        'Session.request',
+        'Session.send',
         _xray_traced_requests
     )
 
@@ -22,7 +22,7 @@ def patch():
 
 def _xray_traced_requests(wrapped, instance, args, kwargs):
 
-    url = kwargs.get('url') or args[1]
+    url = args[1].url
 
     return xray_recorder.record_subsegment(
         wrapped, instance, args, kwargs,


### PR DESCRIPTION
Patching the `send` function instead of `request` (this achieves the same affect)

*Description of changes:*

The requests library uses the `send` function to perform the HTTP call.
The call stack is as follows:
`request` -> `send`
In other words, the `request` function calls the `send` function.

Some third party libraries use the `send` function directly, where they prepare the request (using some request builder function) and then send it with `send`.

A notable example of this is [OpenSearch python client](https://github.com/opensearch-project/opensearch-py/blob/6ab1a7f652f37468e9938a8ba8f23b1052dbab0e/opensearchpy/connection/http_requests.py#L196)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
