### PR TITLE
fix log stack overflow if metadata contains circular reference

### DIFF
--- a/aws_xray_sdk/core/utils/conversion.py
+++ b/aws_xray_sdk/core/utils/conversion.py
@@ -30,6 +30,7 @@ def metadata_to_dict(obj):
             return metadata
         else:
             return obj
-    except Exception:
-        log.exception("Failed to convert metadata to dict")
+    except Exception as e:
+        import pprint
+        log.info("Failed to convert metadata to dict:\n%s", pprint.pformat(getattr(e, "args", None)))
         return {}

--- a/tests/util.py
+++ b/tests/util.py
@@ -4,6 +4,14 @@ import threading
 from aws_xray_sdk.core.recorder import AWSXRayRecorder
 from aws_xray_sdk.core.emitters.udp_emitter import UDPEmitter
 from aws_xray_sdk.core.sampling.sampler import DefaultSampler
+from aws_xray_sdk.core.utils.conversion import metadata_to_dict
+
+
+class CircularReferenceClass:
+    """Test class that can create circular references"""
+    def __init__(self, name):
+        self.name = name
+        self.ref = None
 
 
 class StubbedEmitter(UDPEmitter):
@@ -99,3 +107,15 @@ def _search_entity_by_annotation(entity, key, value):
                     if result is not None:
                         return result
     return None
+
+
+def test_metadata_to_dict_self_reference():
+    """Test that self-referencing objects don't cause stack overflow"""
+    obj = CircularReferenceClass("self_ref")
+    obj.ref = obj  # Self reference
+    
+    # This should not cause stack overflow
+    result = metadata_to_dict(obj)
+    
+    # The function should handle the self reference gracefully
+    assert isinstance(result, dict)


### PR DESCRIPTION
*Issue #, if available:*
When segment metadata contains objects having circular reference, the segment serialization will get RecursionError exception. Then the log.exception in conversion.py will print infinite logs util hitting a new RecursionError exception, causes log flood in user application logs.

*Description of changes:*
Using pprint instead of normal logging. pprint can handle cycles because it tracks objects it has already visited and, when it detects a recursive reference, it prints a placeholder like <Recursion on ...> instead of recursing, preventing log flood. The output looks like
```
Caught exception: dict contains cycle
  attribute: payload ->
{'name': 'loop',
 'self': <Recursion on dict with id=4414423360>}
  attribute: _recorded ->
True
  attribute: _cause_id ->
'6dd1416f68a1c043'
  gc.collect() returned: 51732
----------------------------------------
Caught exception: dict contains cycle
  attribute: payload ->
{'name': 'loop',
 'self': <Recursion on dict with id=4420684992>}
  attribute: _recorded ->
True
  attribute: _cause_id ->
'ac93f095f48beedf'
  gc.collect() returned: 6
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
