### PR TITLE
Move from up/download artifact v3 -> v4

### DIFF
--- a/.github/workflows/IntegrationTesting.yaml
+++ b/.github/workflows/IntegrationTesting.yaml
@@ -26,7 +26,7 @@ jobs:
         run: python setup.py sdist
 
       - name: Upload SDK build artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: sdk-build-artifact
           path: .
@@ -45,7 +45,7 @@ jobs:
           python-version: '3.8'
 
       - name: Download X-Ray SDK build artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: sdk-build-artifact
           path: ./sample-apps/flask
@@ -59,7 +59,7 @@ jobs:
         working-directory: ./sample-apps/flask
 
       - name: Upload WebApp with X-Ray SDK build artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: sdk-flask-build-artifact
           path: ./sample-apps/flask/deploy.zip
@@ -74,7 +74,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Download WebApp with X-Ray SDK build artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: sdk-flask-build-artifact
 
@@ -112,7 +112,7 @@ jobs:
         working-directory: ./terraform
 
       - name: Upload terraform state files for destorying resources
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: terraform-state-artifact
           path: ./terraform
@@ -151,7 +151,7 @@ jobs:
 
     steps:
       - name: Download terraform state artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: terraform-state-artifact
 


### PR DESCRIPTION
See https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/ and https://github.com/aws/aws-xray-sdk-python/actions/runs/17223079110 for context


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
