### PR TITLE
fix(daily-scan): point Trivy at published artifact dependencies

### DIFF
--- a/.github/workflows/daily-scan.yml
+++ b/.github/workflows/daily-scan.yml
@@ -1,7 +1,7 @@
 ## Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 ## SPDX-License-Identifier: Apache-2.0
 # Performs a daily scan of:
-# * The X-Ray Python SDK source code, using Trivy
+# * The X-Ray Python SDK published artifact dependencies, using Trivy
 # * Project dependencies, using DependencyCheck
 #
 #  Publishes results to CloudWatch Metrics.
@@ -79,24 +79,24 @@ jobs:
         if: ${{ steps.dep_scan.outcome != 'success' }}
         run: less dependency-check-report.html
 
-      - name: Perform high severity scan on built artifacts
+      - name: Perform high severity scan on published artifact dependencies
         if: always()
         id: high_scan_latest
         uses: aquasecurity/trivy-action@97e0b3872f55f89b95b2f65b3dbab56962816478 # v0.34.2
         with:
           scan-type: 'fs'
-          scan-ref: '.'
+          scan-ref: 'scan-target/'
           severity: 'CRITICAL,HIGH'
           exit-code: '1'
           scanners: 'vuln'
 
-      - name: Perform low severity scan on built artifacts
+      - name: Perform low severity scan on published artifact dependencies
         if: always()
         id: low_scan_latest
         uses: aquasecurity/trivy-action@97e0b3872f55f89b95b2f65b3dbab56962816478 # v0.34.2
         with:
           scan-type: 'fs'
-          scan-ref: '.'
+          scan-ref: 'scan-target/'
           severity: 'MEDIUM,LOW,UNKNOWN'
           exit-code: '1'
           scanners: 'vuln'


### PR DESCRIPTION
## What
Point Trivy at the published artifact dependency tree (`scan-target/`) instead of scanning the full repo source at HEAD.

## Why
Trivy was scanning `scan-ref: '.'`, which:
- Picked up `sample-apps/flask/requirements.txt` — a sample app with urllib3 CVEs that are NOT in the published SDK
- Scanned source at HEAD, not the released version — a vuln fixed on main but present in the latest release gives a false negative

## How
Changed `scan-ref` from `'.'` to `'scan-target/'`, which already contains `requirements.txt` from `pip install aws-xray-sdk && pip freeze`. Only runtime deps (wrapt, botocore) — no test or sample app deps.

## Local validation
- **Trivy**: Parses `requirements.txt`, 0 vulns (clean — matches expected result since sample app urllib3 CVEs are correctly excluded)